### PR TITLE
Add Subject Tests to Prevent Invalid Subjects

### DIFF
--- a/src/test/java/seedu/tutor/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/tutor/logic/commands/CommandTestUtil.java
@@ -56,6 +56,7 @@ public class CommandTestUtil {
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
+    public static final String INVALID_SUBJECT_DESC = " " + PREFIX_SUBJECT; // empty string not allowed for subjects
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";

--- a/src/test/java/seedu/tutor/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/tutor/logic/commands/EditPersonDescriptorTest.java
@@ -9,6 +9,7 @@ import static seedu.tutor.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.tutor.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.tutor.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.tutor.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.tutor.logic.commands.CommandTestUtil.VALID_SUBJECT_BOB;
 import static seedu.tutor.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
 import org.junit.jupiter.api.Test;
@@ -54,6 +55,10 @@ public class EditPersonDescriptorTest {
 
         // different tags -> returns false
         editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withTags(VALID_TAG_HUSBAND).build();
+        assertFalse(DESC_AMY.equals(editedAmy));
+
+        // different subject -> returns false
+        editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withSubject(VALID_SUBJECT_BOB).build();
         assertFalse(DESC_AMY.equals(editedAmy));
     }
 

--- a/src/test/java/seedu/tutor/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/tutor/logic/parser/AddCommandParserTest.java
@@ -9,6 +9,7 @@ import static seedu.tutor.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static seedu.tutor.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.tutor.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.tutor.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
+import static seedu.tutor.logic.commands.CommandTestUtil.INVALID_SUBJECT_DESC;
 import static seedu.tutor.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.tutor.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.tutor.logic.commands.CommandTestUtil.NAME_DESC_BOB;
@@ -16,18 +17,21 @@ import static seedu.tutor.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.tutor.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.tutor.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.tutor.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.tutor.logic.commands.CommandTestUtil.SUBJECT_DESC_AMY;
 import static seedu.tutor.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.tutor.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.tutor.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.tutor.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.tutor.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.tutor.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.tutor.logic.commands.CommandTestUtil.VALID_SUBJECT_AMY;
 import static seedu.tutor.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.tutor.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.tutor.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.tutor.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.tutor.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.tutor.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.tutor.logic.parser.CliSyntax.PREFIX_SUBJECT;
 import static seedu.tutor.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.tutor.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.tutor.testutil.TypicalPersons.AMY;
@@ -63,12 +67,19 @@ public class AddCommandParserTest {
         assertParseSuccess(parser,
                 NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 new AddCommand(expectedPersonMultipleTags));
+
+        // subject - accepted
+        Person expectedPersonWithSubject = new PersonBuilder(BOB).withSubject(VALID_SUBJECT_AMY).withTags().build();
+        assertParseSuccess(parser,
+                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + SUBJECT_DESC_AMY,
+                new AddCommand(expectedPersonWithSubject));
     }
 
     @Test
     public void parse_repeatedNonTagValue_failure() {
         String validExpectedPersonString = NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + TAG_DESC_FRIEND;
+        String validExpectedPersonStringWithSubject = validExpectedPersonString + SUBJECT_DESC_AMY;
 
         // multiple names
         assertParseFailure(parser, NAME_DESC_AMY + validExpectedPersonString,
@@ -85,6 +96,10 @@ public class AddCommandParserTest {
         // multiple addresses
         assertParseFailure(parser, ADDRESS_DESC_AMY + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
+
+        // multiple subjects
+        assertParseFailure(parser, SUBJECT_DESC_AMY + validExpectedPersonStringWithSubject,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_SUBJECT));
 
         // multiple fields repeated
         assertParseFailure(parser,
@@ -110,6 +125,10 @@ public class AddCommandParserTest {
         assertParseFailure(parser, INVALID_ADDRESS_DESC + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
 
+        // invalid subject
+        assertParseFailure(parser, INVALID_SUBJECT_DESC + validExpectedPersonStringWithSubject,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_SUBJECT));
+
         // valid value followed by invalid value
 
         // invalid name
@@ -127,11 +146,15 @@ public class AddCommandParserTest {
         // invalid address
         assertParseFailure(parser, validExpectedPersonString + INVALID_ADDRESS_DESC,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
+
+        // invalid subject
+        assertParseFailure(parser, validExpectedPersonStringWithSubject + INVALID_SUBJECT_DESC,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_SUBJECT));
     }
 
     @Test
     public void parse_optionalFieldsMissing_success() {
-        // zero tags
+        // zero tags and subject omitted
         Person expectedPerson = new PersonBuilder(AMY).withTags().build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY,
                 new AddCommand(expectedPerson));
@@ -183,6 +206,10 @@ public class AddCommandParserTest {
         // invalid tag
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                 + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+
+        // invalid subject
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + INVALID_SUBJECT_DESC, "Subject should not be empty");
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC,

--- a/src/test/java/seedu/tutor/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/tutor/logic/parser/ParserUtilTest.java
@@ -25,12 +25,14 @@ public class ParserUtilTest {
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
+    private static final String INVALID_SUBJECT = " ";
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_EMAIL = "rachel@example.com";
+    private static final String VALID_SUBJECT = "Physics";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
 
@@ -192,5 +194,26 @@ public class ParserUtilTest {
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseSubject_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseSubject(null));
+    }
+
+    @Test
+    public void parseSubject_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseSubject(INVALID_SUBJECT));
+    }
+
+    @Test
+    public void parseSubject_validValueWithoutWhitespace_returnsSubject() throws Exception {
+        assertEquals(VALID_SUBJECT, ParserUtil.parseSubject(VALID_SUBJECT));
+    }
+
+    @Test
+    public void parseSubject_validValueWithWhitespace_returnsTrimmedSubject() throws Exception {
+        String subjectWithWhitespace = WHITESPACE + VALID_SUBJECT + WHITESPACE;
+        assertEquals(VALID_SUBJECT, ParserUtil.parseSubject(subjectWithWhitespace));
     }
 }

--- a/src/test/java/seedu/tutor/model/person/PersonTest.java
+++ b/src/test/java/seedu/tutor/model/person/PersonTest.java
@@ -7,6 +7,7 @@ import static seedu.tutor.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.tutor.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.tutor.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.tutor.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.tutor.logic.commands.CommandTestUtil.VALID_SUBJECT_BOB;
 import static seedu.tutor.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.tutor.testutil.Assert.assertThrows;
 import static seedu.tutor.testutil.TypicalPersons.ALICE;
@@ -87,6 +88,10 @@ public class PersonTest {
 
         // different tags -> returns false
         editedAlice = new PersonBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();
+        assertFalse(ALICE.equals(editedAlice));
+
+        // different subject -> returns false
+        editedAlice = new PersonBuilder(ALICE).withSubject(VALID_SUBJECT_BOB).build();
         assertFalse(ALICE.equals(editedAlice));
     }
 

--- a/src/test/java/seedu/tutor/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/tutor/storage/JsonAdaptedPersonTest.java
@@ -120,4 +120,20 @@ public class JsonAdaptedPersonTest {
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
+    @Test
+    public void toModelType_nullSubject_returnsPersonWithEmptySubject() throws Exception {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                        VALID_ADDRESS, null, VALID_TAGS, VALID_RELATIONS);
+        assertEquals("", person.toModelType().getSubject());
+    }
+
+    @Test
+    public void toModelType_emptySubject_returnsPersonWithEmptySubject() throws Exception {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                        VALID_ADDRESS, "", VALID_TAGS, VALID_RELATIONS);
+        assertEquals("", person.toModelType().getSubject());
+    }
+
 }


### PR DESCRIPTION
Add invalid subject tests such as whitespace subjects. 

This prevents users from adding a subject with "s/" followed by whitespace, but does not prevent editing subjects to an empty string

Closes #72 