### PR TITLE
Change display format of relation

### DIFF
--- a/src/main/java/seedu/tutor/model/person/Person.java
+++ b/src/main/java/seedu/tutor/model/person/Person.java
@@ -108,6 +108,31 @@ public class Person {
     }
 
     /**
+     * Returns a set of all relations formatted for display.
+     * For example, given current Person = Amy,
+     * Relation "Amy/Bob/teacher/student"  or "Bob/Amy/student/teacher"
+     * will be formatted as "Bob (student)"
+     */
+    public Set<String> formatRelationNames() {
+        Set<String> formattedRelationNames = new HashSet<>();
+        for (Relation relation : relations) {
+
+            // First person is self
+            String[] args = relation.relationName.split("/");
+            String otherPerson = args[1];
+            String otherPersonRelation = args[3];
+
+            if (Objects.equals(args[1], name.fullName)) { // Second person is self
+                otherPerson = args[0];
+                otherPersonRelation = args[2];
+            }
+
+            formattedRelationNames.add(String.format(otherPerson + " (" + otherPersonRelation + ")"));
+        }
+        return formattedRelationNames;
+    }
+
+    /**
      * Returns true if both persons have the same identity and data fields.
      * This defines a stronger notion of equality between two persons.
      */

--- a/src/main/java/seedu/tutor/ui/PersonCard.java
+++ b/src/main/java/seedu/tutor/ui/PersonCard.java
@@ -67,8 +67,8 @@ public class PersonCard extends UiPart<Region> {
             subject.setText("Subject: " + person.getSubject());
         }
 
-        person.getRelations().stream()
-                .sorted(Comparator.comparing(relation -> relation.relationName))
-                .forEach(relation -> relations.getChildren().add(new Label(relation.relationName)));
+        person.formatRelationNames().stream()
+                .sorted(Comparator.comparing(String::toString))
+                .forEach(formattedRelation -> relations.getChildren().add(new Label(formattedRelation)));
     }
 }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -358,7 +358,7 @@
 
 #relations .label {
     -fx-text-fill: white;
-    -fx-background-color: #3e7b91;
+    -fx-background-color: #3e9157;
     -fx-padding: 1 3 1 3;
     -fx-border-radius: 2;
     -fx-background-radius: 2;


### PR DESCRIPTION
Closes #82.

Change display format of relation to be more intuitive.

Example:
Given relation `Amy/Bob/teacher/student`  or `Bob/Amy/student/teacher` stored in both `Amy` and `Bob`,
In `Amy`, relation will be formatted as `Bob (student)`.
In `Bob`, relation will be formatted as `Amy (teacher)`.