### PR TITLE
Update subject to be a hashset instead of a field

### DIFF
--- a/src/main/java/seedu/tutor/logic/Messages.java
+++ b/src/main/java/seedu/tutor/logic/Messages.java
@@ -43,13 +43,10 @@ public class Messages {
                 .append("; Email: ")
                 .append(person.getEmail())
                 .append("; Address: ")
-                .append(person.getAddress())
-                .append("; Subject: ");
-        if (!person.getSubject().isBlank()) {
-            builder.append(person.getSubject());
-            builder.append("; ");
-        }
-        builder.append("Tags: ");
+                .append(person.getAddress());
+        builder.append(" Subjects: ");
+        person.getSubjects().forEach(builder::append);
+        builder.append(" Tags: ");
         person.getTags().forEach(builder::append);
         return builder.toString();
     }

--- a/src/main/java/seedu/tutor/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/EditCommand.java
@@ -104,7 +104,7 @@ public class EditCommand extends Command {
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
         Set<Relation> updatedRelations = editPersonDescriptor.getRelations().orElse(personToEdit.getRelations());
-        String updatedSubject = editPersonDescriptor.getSubject().orElse(personToEdit.getSubject());
+        Set<Tag> updatedSubject = editPersonDescriptor.getSubjects().orElse(personToEdit.getSubjects());
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags,
                 updatedRelations, updatedSubject);
@@ -145,7 +145,7 @@ public class EditCommand extends Command {
         private Address address;
         private Set<Tag> tags;
         private Set<Relation> relations;
-        private String subject;
+        private Set<Tag> subjects;
 
         public EditPersonDescriptor() {}
 
@@ -160,14 +160,14 @@ public class EditCommand extends Command {
             setAddress(toCopy.address);
             setTags(toCopy.tags);
             setRelations(toCopy.relations);
-            setSubject(toCopy.subject);
+            setSubjects(toCopy.subjects);
         }
 
         /**
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags, relations, subject);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags, relations, subjects);
         }
 
         public void setName(Name name) {
@@ -220,6 +220,23 @@ public class EditCommand extends Command {
         }
 
         /**
+         * Sets {@code subjects} to this object's {@code subjects}.
+         * A defensive copy of {@code subjects} is used internally.
+         */
+        public void setSubjects(Set<Tag> subjects) {
+            this.subjects = (subjects != null) ? new HashSet<>(subjects) : null;
+        }
+
+        /**
+         * Returns an unmodifiable subjects set, which throws {@code UnsupportedOperationException}
+         * if modification is attempted.
+         * Returns {@code Optional#empty()} if {@code subjects} is null.
+         */
+        public Optional<Set<Tag>> getSubjects() {
+            return (subjects != null) ? Optional.of(Collections.unmodifiableSet(subjects)) : Optional.empty();
+        }
+
+        /**
          * Sets {@code relations} to this object's {@code relations}.
          * A defensive copy of {@code relations} is used internally.
          */
@@ -234,14 +251,6 @@ public class EditCommand extends Command {
          */
         public Optional<Set<Relation>> getRelations() {
             return (relations != null) ? Optional.of(Collections.unmodifiableSet(relations)) : Optional.empty();
-        }
-
-        public void setSubject(String subject) {
-            this.subject = subject;
-        }
-
-        public Optional<String> getSubject() {
-            return Optional.ofNullable(subject);
         }
 
         @Override
@@ -262,7 +271,7 @@ public class EditCommand extends Command {
                     && Objects.equals(address, otherEditPersonDescriptor.address)
                     && Objects.equals(tags, otherEditPersonDescriptor.tags)
                     && Objects.equals(relations, otherEditPersonDescriptor.relations)
-                    && Objects.equals(subject, otherEditPersonDescriptor.subject);
+                    && Objects.equals(subjects, otherEditPersonDescriptor.subjects);
         }
 
         @Override
@@ -274,7 +283,7 @@ public class EditCommand extends Command {
                     .add("address", address)
                     .add("tags", tags)
                     .add("relations", relations)
-                    .add("subject", subject)
+                    .add("subject", subjects)
                     .toString();
         }
     }

--- a/src/main/java/seedu/tutor/logic/commands/RelateAddCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/RelateAddCommand.java
@@ -72,7 +72,7 @@ public class RelateAddCommand extends RelateCommand {
                 personToAddRelation.getAddress(),
                 personToAddRelation.getTags(),
                 updatedRelations,
-                personToAddRelation.getSubject()
+                personToAddRelation.getSubjects()
         );
     }
 

--- a/src/main/java/seedu/tutor/logic/commands/RelateDeleteCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/RelateDeleteCommand.java
@@ -77,7 +77,7 @@ public class RelateDeleteCommand extends RelateCommand {
                 personToDeleteRelation.getAddress(),
                 personToDeleteRelation.getTags(),
                 updatedRelations,
-                personToDeleteRelation.getSubject()
+                personToDeleteRelation.getSubjects()
         );
     }
 

--- a/src/main/java/seedu/tutor/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/tutor/logic/parser/AddCommandParser.java
@@ -43,19 +43,16 @@ public class AddCommandParser implements Parser<AddCommand> {
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                PREFIX_ADDRESS, PREFIX_SUBJECT);
+                PREFIX_ADDRESS);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
         Set<Relation> relationList = ParserUtil.parseRelations(argMultimap.getAllValues(PREFIX_RELATION));
-        String subject = "";
-        if (argMultimap.getValue(PREFIX_SUBJECT).isPresent()) {
-            subject = ParserUtil.parseSubject(argMultimap.getValue(PREFIX_SUBJECT).get());
-        }
+        Set<Tag> subjectList = ParserUtil.parseSubjects(argMultimap.getAllValues(PREFIX_SUBJECT));
 
-        Person person = new Person(name, phone, email, address, tagList, relationList, subject);
+        Person person = new Person(name, phone, email, address, tagList, relationList, subjectList);
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/tutor/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/tutor/logic/parser/EditCommandParser.java
@@ -60,11 +60,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
             editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
         }
-        if (argMultimap.getValue(PREFIX_SUBJECT).isPresent()) {
-            editPersonDescriptor.setSubject(argMultimap.getValue(PREFIX_SUBJECT).get());
-        }
 
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
+
+        parseSubjectsForEdit(argMultimap.getAllValues(PREFIX_SUBJECT)).ifPresent(editPersonDescriptor::setSubjects);
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
@@ -88,4 +87,19 @@ public class EditCommandParser implements Parser<EditCommand> {
         return Optional.of(ParserUtil.parseTags(tagSet));
     }
 
+    /**
+     * Parses {@code Collection<String> subjects} into a {@code Set<Tag>} if {@code subjects} is non-empty.
+     * If {@code subjects} contain only one element which is an empty string, it will be parsed into a
+     * {@code Set<Tag>} containing zero tags.
+     */
+    private Optional<Set<Tag>> parseSubjectsForEdit(Collection<String> subjects) throws ParseException {
+        assert subjects != null;
+
+        if (subjects.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> subjectSet = subjects.size() == 1 && subjects.contains("")
+                ? Collections.emptySet() : subjects;
+        return Optional.of(ParserUtil.parseTags(subjectSet));
+    }
 }

--- a/src/main/java/seedu/tutor/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/tutor/logic/parser/ParserUtil.java
@@ -112,21 +112,6 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String tag} into a {@code Subject}.
-     * Leading and trailing whitespaces will be trimmed.
-     *
-     * @throws ParseException if the given {@code Subject} is invalid.
-     */
-    public static String parseSubject(String subject) throws ParseException {
-        requireNonNull(subject);
-        String trimmedSubject = subject.trim();
-        if (trimmedSubject.isEmpty()) {
-            throw new ParseException("Subject should not be empty");
-        }
-        return trimmedSubject;
-    }
-
-    /**
      * Parses {@code Collection<String> tags} into a {@code Set<Tag>}.
      */
     public static Set<Tag> parseTags(Collection<String> tags) throws ParseException {
@@ -137,6 +122,34 @@ public class ParserUtil {
         }
         return tagSet;
     }
+
+    /**
+     * Parses a {@code String subject} into a {@code Subject}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code Subject} is invalid.
+     */
+    public static Tag parseSubject(String subject) throws ParseException {
+        requireNonNull(subject);
+        String trimmedSubject = subject.trim();
+        if (!Tag.isValidTagName(trimmedSubject)) {
+            throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
+        }
+        return new Tag(trimmedSubject);
+    }
+
+    /**
+     * Parses {@code Collection<String> subjects} into a {@code Set<Tag>}.
+     */
+    public static Set<Tag> parseSubjects(Collection<String> tags) throws ParseException {
+        requireNonNull(tags);
+        final Set<Tag> subjectSet = new HashSet<>();
+        for (String tagName : tags) {
+            subjectSet.add(parseTag(tagName));
+        }
+        return subjectSet;
+    }
+
 
     /**
      * Parses a {@code String relations} into a {@code Relation}.

--- a/src/main/java/seedu/tutor/model/person/Person.java
+++ b/src/main/java/seedu/tutor/model/person/Person.java
@@ -26,31 +26,14 @@ public class Person {
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
     private final Set<Relation> relations = new HashSet<>();
-    private final String subject;
-
-    /**
-     * Every field must be present and not null.
-     */
-    /* these person constructors are for app to run currently. Once subject and relations are fully added,
-        then they can be removed
-     */
-    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags, Set<Relation> relations) {
-        this(name, phone, email, address, tags, relations, "");
-    }
-
-    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
-        this(name, phone, email, address, tags, new HashSet<>(), "");
-    }
-
-    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags, String subject) {
-        this(name, phone, email, address, tags, new HashSet<>(), subject);
-    }
+    // private final String subject;
+    private final Set<Tag> subject = new HashSet<>();
 
     /**
      * Complete constructor for person, other constructors kept for dependency to be removed over time
      */
     public Person(Name name, Phone phone, Email email, Address address,
-                  Set<Tag> tags, Set<Relation> relations, String subject) {
+                  Set<Tag> tags, Set<Relation> relations, Set<Tag> subject) {
         requireAllNonNull(name, phone, email, address, tags, relations, subject);
         this.name = name;
         this.phone = phone;
@@ -58,7 +41,7 @@ public class Person {
         this.address = address;
         this.tags.addAll(tags);
         this.relations.addAll(relations);
-        this.subject = subject;
+        this.subject.addAll(subject);
     }
 
     public Name getName() {
@@ -77,8 +60,8 @@ public class Person {
         return address;
     }
 
-    public String getSubject() {
-        return subject;
+    public Set<Tag> getSubjects() {
+        return Collections.unmodifiableSet(subject);
     }
 
     /**

--- a/src/main/java/seedu/tutor/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/tutor/model/util/SampleDataUtil.java
@@ -22,22 +22,22 @@ public class SampleDataUtil {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"),
-                getTagSet("friends"), getRelationSet()),
+                getTagSet("friends"), getRelationSet(), getSubjectSet("Maths", "Science")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                getTagSet("colleagues", "friends"), getRelationSet()),
+                getTagSet("colleagues", "friends"), getRelationSet(), getSubjectSet("English")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                getTagSet("neighbours"), getRelationSet()),
+                getTagSet("neighbours"), getRelationSet(), getSubjectSet("Chinese")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
-                getTagSet("family"), getRelationSet()),
+                getTagSet("family"), getRelationSet(), getSubjectSet("Science")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"),
-                getTagSet("classmates"), getRelationSet()),
+                getTagSet("classmates"), getRelationSet(), getSubjectSet("Maths")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"),
-                getTagSet("colleagues"), getRelationSet())
+                getTagSet("colleagues"), getRelationSet(), getSubjectSet("English")),
         };
     }
 
@@ -53,6 +53,12 @@ public class SampleDataUtil {
      * Returns a tag set containing the list of strings given.
      */
     public static Set<Tag> getTagSet(String... strings) {
+        return Arrays.stream(strings)
+                .map(Tag::new)
+                .collect(Collectors.toSet());
+    }
+
+    public static Set<Tag> getSubjectSet(String... strings) {
         return Arrays.stream(strings)
                 .map(Tag::new)
                 .collect(Collectors.toSet());

--- a/src/main/java/seedu/tutor/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/tutor/storage/JsonAdaptedPerson.java
@@ -29,7 +29,7 @@ class JsonAdaptedPerson {
     private final String phone;
     private final String email;
     private final String address;
-    private final String subject;
+    private final List<JsonAdaptedTag> subject = new ArrayList<>();
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
     private final List<JsonAdaptedRelation> relations = new ArrayList<>();
 
@@ -39,13 +39,16 @@ class JsonAdaptedPerson {
     @JsonCreator
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
                              @JsonProperty("email") String email, @JsonProperty("address") String address,
-                             @JsonProperty("subject") String subject, @JsonProperty("tags") List<JsonAdaptedTag> tags,
+                             @JsonProperty("subject") List<JsonAdaptedTag> subject,
+                             @JsonProperty("tags") List<JsonAdaptedTag> tags,
                              @JsonProperty("relations") List<JsonAdaptedRelation> relations) {
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
-        this.subject = subject;
+        if (subject != null) {
+            this.subject.addAll(subject);
+        }
         if (tags != null) {
             this.tags.addAll(tags);
         }
@@ -62,7 +65,9 @@ class JsonAdaptedPerson {
         phone = source.getPhone().value;
         email = source.getEmail().value;
         address = source.getAddress().value;
-        subject = source.getSubject();
+        subject.addAll(source.getSubjects().stream()
+                .map(JsonAdaptedTag::new)
+                .collect(Collectors.toList()));
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
@@ -80,6 +85,11 @@ class JsonAdaptedPerson {
         final List<Tag> personTags = new ArrayList<>();
         for (JsonAdaptedTag tag : tags) {
             personTags.add(tag.toModelType());
+        }
+
+        final List<Tag> personSubjects = new ArrayList<>();
+        for (JsonAdaptedTag subject : subject) {
+            personSubjects.add(subject.toModelType());
         }
 
         final List<Relation> personRelations = new ArrayList<>();
@@ -119,7 +129,7 @@ class JsonAdaptedPerson {
         }
         final Address modelAddress = new Address(address);
 
-        final String modelSubject = (subject == null) ? "" : subject;
+        final Set<Tag> modelSubject = new HashSet<>(personSubjects);
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
 

--- a/src/main/java/seedu/tutor/ui/PersonCard.java
+++ b/src/main/java/seedu/tutor/ui/PersonCard.java
@@ -41,7 +41,7 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private FlowPane tags;
     @FXML
-    private Label subject;
+    private FlowPane subjects;
     @FXML
     private FlowPane relations;
 
@@ -61,11 +61,9 @@ public class PersonCard extends UiPart<Region> {
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
 
-        if (person.getSubject().isBlank()) {
-            subject.setText("");
-        } else {
-            subject.setText("Subject: " + person.getSubject());
-        }
+        person.getSubjects().stream()
+                .sorted(Comparator.comparing(subject -> subject.tagName))
+                .forEach(subject -> subjects.getChildren().add(new Label(subject.tagName)));
 
         person.formatRelationNames().stream()
                 .sorted(Comparator.comparing(String::toString))

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -351,6 +351,20 @@
     -fx-font-size: 11;
 }
 
+#subjects {
+    -fx-hgap: 7;
+    -fx-vgap: 3;
+}
+
+#subjects .label {
+    -fx-text-fill: white;
+    -fx-background-color: #d32f2f;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 11;
+}
+
 #relations {
     -fx-hgap: 7;
     -fx-vgap: 3;

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -31,7 +31,7 @@
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-      <Label fx:id="subject" styleClass="cell_small_label" text="Subject: "/>
+      <FlowPane fx:id="subjects" />
       <FlowPane fx:id="relations" />
     </VBox>
   </GridPane>

--- a/src/test/data/JsonSerializableTutorMapTest/typicalPersonsTutorMap.json
+++ b/src/test/data/JsonSerializableTutorMapTest/typicalPersonsTutorMap.json
@@ -7,7 +7,7 @@
     "address" : "123, Jurong West Ave 6, #08-111",
     "tags" : [ "friends" ],
     "relations": [ "Elle Meyer/Alice Pauline/mother/child" ],
-    "subject": "math"
+    "subject": [ "math" ]
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",
@@ -15,7 +15,7 @@
     "address" : "311, Clementi Ave 2, #02-25",
     "tags" : [ "owesMoney", "friends" ],
     "relations": [ "Elle Meyer/Benson Meier/mother/child" ],
-    "subject": "math"
+    "subject": [ "math" ]
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",

--- a/src/test/java/seedu/tutor/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/tutor/logic/commands/CommandTestUtil.java
@@ -56,7 +56,7 @@ public class CommandTestUtil {
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
-    public static final String INVALID_SUBJECT_DESC = " " + PREFIX_SUBJECT; // empty string not allowed for subjects
+    public static final String INVALID_SUBJECT_DESC = " " + PREFIX_SUBJECT + "*Science"; // '*' not allowed in subjects
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
@@ -68,10 +68,10 @@ public class CommandTestUtil {
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
-                .withSubject(VALID_SUBJECT_AMY).withTags(VALID_TAG_FRIEND).build();
+                .withSubjects(VALID_SUBJECT_AMY).withTags(VALID_TAG_FRIEND).build();
         DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
-                .withSubject(VALID_SUBJECT_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withSubjects(VALID_SUBJECT_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
     }
 
     /**

--- a/src/test/java/seedu/tutor/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/tutor/logic/commands/EditCommandTest.java
@@ -153,10 +153,10 @@ public class EditCommandTest {
         Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
 
         PersonBuilder personInList = new PersonBuilder(lastPerson);
-        Person editedPerson = personInList.withSubject(VALID_SUBJECT_AMY).build();
+        Person editedPerson = personInList.withSubjects(VALID_SUBJECT_AMY).build();
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
-                .withSubject(VALID_SUBJECT_AMY).build();
+                .withSubjects(VALID_SUBJECT_AMY).build();
         EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS,

--- a/src/test/java/seedu/tutor/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/tutor/logic/commands/EditPersonDescriptorTest.java
@@ -58,7 +58,7 @@ public class EditPersonDescriptorTest {
         assertFalse(DESC_AMY.equals(editedAmy));
 
         // different subject -> returns false
-        editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withSubject(VALID_SUBJECT_BOB).build();
+        editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withSubjects(VALID_SUBJECT_BOB).build();
         assertFalse(DESC_AMY.equals(editedAmy));
     }
 
@@ -72,7 +72,7 @@ public class EditPersonDescriptorTest {
                 + editPersonDescriptor.getAddress().orElse(null) + ", tags="
                 + editPersonDescriptor.getTags().orElse(null) + ", relations="
                 + editPersonDescriptor.getRelations().orElse(null) + ", subject="
-                + editPersonDescriptor.getSubject().orElse(null) + "}";
+                + editPersonDescriptor.getSubjects().orElse(null) + "}";
         assertEquals(expected, editPersonDescriptor.toString());
     }
 }

--- a/src/test/java/seedu/tutor/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/tutor/logic/parser/AddCommandParserTest.java
@@ -31,7 +31,6 @@ import static seedu.tutor.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.tutor.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.tutor.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.tutor.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.tutor.logic.parser.CliSyntax.PREFIX_SUBJECT;
 import static seedu.tutor.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.tutor.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.tutor.testutil.TypicalPersons.AMY;
@@ -69,7 +68,7 @@ public class AddCommandParserTest {
                 new AddCommand(expectedPersonMultipleTags));
 
         // subject - accepted
-        Person expectedPersonWithSubject = new PersonBuilder(BOB).withSubject(VALID_SUBJECT_AMY).withTags().build();
+        Person expectedPersonWithSubject = new PersonBuilder(BOB).withSubjects(VALID_SUBJECT_AMY).withTags().build();
         assertParseSuccess(parser,
                 NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + SUBJECT_DESC_AMY,
                 new AddCommand(expectedPersonWithSubject));
@@ -97,10 +96,6 @@ public class AddCommandParserTest {
         assertParseFailure(parser, ADDRESS_DESC_AMY + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
 
-        // multiple subjects
-        assertParseFailure(parser, SUBJECT_DESC_AMY + validExpectedPersonStringWithSubject,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_SUBJECT));
-
         // multiple fields repeated
         assertParseFailure(parser,
                 validExpectedPersonString + PHONE_DESC_AMY + EMAIL_DESC_AMY + NAME_DESC_AMY + ADDRESS_DESC_AMY
@@ -125,10 +120,6 @@ public class AddCommandParserTest {
         assertParseFailure(parser, INVALID_ADDRESS_DESC + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
 
-        // invalid subject
-        assertParseFailure(parser, INVALID_SUBJECT_DESC + validExpectedPersonStringWithSubject,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_SUBJECT));
-
         // valid value followed by invalid value
 
         // invalid name
@@ -146,10 +137,6 @@ public class AddCommandParserTest {
         // invalid address
         assertParseFailure(parser, validExpectedPersonString + INVALID_ADDRESS_DESC,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
-
-        // invalid subject
-        assertParseFailure(parser, validExpectedPersonStringWithSubject + INVALID_SUBJECT_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_SUBJECT));
     }
 
     @Test
@@ -209,7 +196,7 @@ public class AddCommandParserTest {
 
         // invalid subject
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + INVALID_SUBJECT_DESC, "Subject should not be empty");
+                + INVALID_SUBJECT_DESC, Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC,

--- a/src/test/java/seedu/tutor/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/tutor/logic/parser/EditCommandParserTest.java
@@ -216,7 +216,7 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_THIRD_PERSON;
         String userInput = targetIndex.getOneBased() + SUBJECT_DESC_AMY;
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
-                .withSubject(VALID_SUBJECT_AMY).build();
+                .withSubjects(VALID_SUBJECT_AMY).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }

--- a/src/test/java/seedu/tutor/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/tutor/logic/parser/ParserUtilTest.java
@@ -32,7 +32,8 @@ public class ParserUtilTest {
     private static final String VALID_PHONE = "123456";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_EMAIL = "rachel@example.com";
-    private static final String VALID_SUBJECT = "Physics";
+    private static final String VALID_SUBJECT_1 = "Physics";
+    private static final String VALID_SUBJECT_2 = "Chemistry";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
 
@@ -196,6 +197,7 @@ public class ParserUtilTest {
         assertEquals(expectedTagSet, actualTagSet);
     }
 
+    //subject testing
     @Test
     public void parseSubject_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> ParserUtil.parseSubject(null));
@@ -208,12 +210,14 @@ public class ParserUtilTest {
 
     @Test
     public void parseSubject_validValueWithoutWhitespace_returnsSubject() throws Exception {
-        assertEquals(VALID_SUBJECT, ParserUtil.parseSubject(VALID_SUBJECT));
+        Tag expectedSubject = new Tag(VALID_SUBJECT_1);
+        assertEquals(expectedSubject, ParserUtil.parseSubject(VALID_SUBJECT_1));
     }
 
     @Test
     public void parseSubject_validValueWithWhitespace_returnsTrimmedSubject() throws Exception {
-        String subjectWithWhitespace = WHITESPACE + VALID_SUBJECT + WHITESPACE;
-        assertEquals(VALID_SUBJECT, ParserUtil.parseSubject(subjectWithWhitespace));
+        String tagWithWhitespace = WHITESPACE + VALID_SUBJECT_1 + WHITESPACE;
+        Tag expectedSubject = new Tag(VALID_SUBJECT_1);
+        assertEquals(expectedSubject, ParserUtil.parseTag(tagWithWhitespace));
     }
 }

--- a/src/test/java/seedu/tutor/model/person/PersonTest.java
+++ b/src/test/java/seedu/tutor/model/person/PersonTest.java
@@ -91,7 +91,7 @@ public class PersonTest {
         assertFalse(ALICE.equals(editedAlice));
 
         // different subject -> returns false
-        editedAlice = new PersonBuilder(ALICE).withSubject(VALID_SUBJECT_BOB).build();
+        editedAlice = new PersonBuilder(ALICE).withSubjects(VALID_SUBJECT_BOB).build();
         assertFalse(ALICE.equals(editedAlice));
     }
 
@@ -99,7 +99,7 @@ public class PersonTest {
     public void toStringMethod() {
         String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags()
-                + ", relations=" + ALICE.getRelations() + ", subjects=" + ALICE.getSubject() + "}";
+                + ", relations=" + ALICE.getRelations() + ", subjects=" + ALICE.getSubjects() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/tutor/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/tutor/storage/JsonAdaptedPersonTest.java
@@ -34,7 +34,9 @@ public class JsonAdaptedPersonTest {
     private static final List<JsonAdaptedRelation> VALID_RELATIONS = BENSON.getRelations().stream()
             .map(JsonAdaptedRelation::new)
             .collect(Collectors.toList());
-    private static final String VALID_SUBJECT = BENSON.getSubject();
+    private static final List<JsonAdaptedTag> VALID_SUBJECTS = BENSON.getSubjects().stream()
+            .map(JsonAdaptedTag::new)
+            .collect(Collectors.toList());
 
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
@@ -46,14 +48,14 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL,
-                        VALID_ADDRESS, VALID_SUBJECT, VALID_TAGS, VALID_RELATIONS);
+                        VALID_ADDRESS, VALID_SUBJECTS, VALID_TAGS, VALID_RELATIONS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_SUBJECT,
+        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_SUBJECTS,
                 VALID_TAGS, VALID_RELATIONS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
@@ -62,16 +64,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_SUBJECT,
-                        VALID_ADDRESS, VALID_TAGS, VALID_RELATIONS);
+                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL,
+                        VALID_ADDRESS, VALID_SUBJECTS, VALID_TAGS, VALID_RELATIONS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_SUBJECT,
-                VALID_ADDRESS, VALID_TAGS, VALID_RELATIONS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL,
+                VALID_ADDRESS, VALID_SUBJECTS, VALID_TAGS, VALID_RELATIONS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -80,7 +82,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL,
-                        VALID_ADDRESS, VALID_SUBJECT, VALID_TAGS, VALID_RELATIONS);
+                        VALID_ADDRESS, VALID_SUBJECTS, VALID_TAGS, VALID_RELATIONS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -88,7 +90,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null,
-                VALID_ADDRESS, VALID_SUBJECT, VALID_TAGS, VALID_RELATIONS);
+                VALID_ADDRESS, VALID_SUBJECTS, VALID_TAGS, VALID_RELATIONS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -97,14 +99,14 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                        INVALID_ADDRESS, VALID_SUBJECT, VALID_TAGS, VALID_RELATIONS);
+                        INVALID_ADDRESS, VALID_SUBJECTS, VALID_TAGS, VALID_RELATIONS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_SUBJECT,
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_SUBJECTS,
                 VALID_TAGS, VALID_RELATIONS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
@@ -116,24 +118,7 @@ public class JsonAdaptedPersonTest {
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                        VALID_ADDRESS, VALID_SUBJECT, invalidTags, VALID_RELATIONS);
+                        VALID_ADDRESS, VALID_SUBJECTS, invalidTags, VALID_RELATIONS);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
-
-    @Test
-    public void toModelType_nullSubject_returnsPersonWithEmptySubject() throws Exception {
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                        VALID_ADDRESS, null, VALID_TAGS, VALID_RELATIONS);
-        assertEquals("", person.toModelType().getSubject());
-    }
-
-    @Test
-    public void toModelType_emptySubject_returnsPersonWithEmptySubject() throws Exception {
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                        VALID_ADDRESS, "", VALID_TAGS, VALID_RELATIONS);
-        assertEquals("", person.toModelType().getSubject());
-    }
-
 }

--- a/src/test/java/seedu/tutor/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/tutor/testutil/EditPersonDescriptorBuilder.java
@@ -40,7 +40,7 @@ public class EditPersonDescriptorBuilder {
         descriptor.setAddress(person.getAddress());
         descriptor.setTags(person.getTags());
         descriptor.setRelations(person.getRelations());
-        descriptor.setSubject(person.getSubject());
+        descriptor.setSubjects(person.getSubjects());
     }
 
     /**
@@ -86,20 +86,22 @@ public class EditPersonDescriptorBuilder {
     }
 
     /**
+     * Parses the {@code subjects} into a {@code Set<Tag>} and set it to the {@code EditPersonDescriptor}
+     * that we are building.
+     */
+    public EditPersonDescriptorBuilder withSubjects(String... subjects) {
+        Set<Tag> subjectSet = Stream.of(subjects).map(Tag::new).collect(Collectors.toSet());
+        descriptor.setSubjects(subjectSet);
+        return this;
+    }
+
+    /**
      * Parses the {@code relations} into a {@code Set<Relation>} and set it to the {@code EditPersonDescriptor}
      * that we are building.
      */
     public EditPersonDescriptorBuilder withRelations(String... relations) {
         Set<Relation> relationSet = Stream.of(relations).map(Relation::new).collect(Collectors.toSet());
         descriptor.setRelations(relationSet);
-        return this;
-    }
-
-    /**
-     * Sets the {@code Subject} of the {@code EditPersonDescriptor} that we are building.
-     */
-    public EditPersonDescriptorBuilder withSubject(String subject) {
-        descriptor.setSubject(subject);
         return this;
     }
 

--- a/src/test/java/seedu/tutor/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/tutor/testutil/PersonBuilder.java
@@ -21,14 +21,13 @@ public class PersonBuilder {
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
-    public static final String DEFAULT_SUBJECT = "";
 
     private Name name;
     private Phone phone;
     private Email email;
     private Address address;
     private Set<Tag> tags;
-    private String subjects;
+    private Set<Tag> subjects;
     private Set<Relation> relations;
 
     /**
@@ -40,7 +39,7 @@ public class PersonBuilder {
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
         tags = new HashSet<>();
-        subjects = DEFAULT_SUBJECT;
+        subjects = new HashSet<>();
         relations = new HashSet<>();
     }
 
@@ -53,7 +52,7 @@ public class PersonBuilder {
         email = personToCopy.getEmail();
         address = personToCopy.getAddress();
         tags = new HashSet<>(personToCopy.getTags());
-        subjects = personToCopy.getSubject();
+        subjects = new HashSet<>(personToCopy.getSubjects());
         relations = new HashSet<>(personToCopy.getRelations());
     }
 
@@ -98,10 +97,10 @@ public class PersonBuilder {
     }
 
     /**
-     * Sets the {@code Subject} of the {@code Person} that we are building.
+     * Parses the {@code subjects} into a {@code Set<Subject>} and set it to the {@code Person} that we are building.
      */
-    public PersonBuilder withSubject(String subject) {
-        this.subjects = subject;
+    public PersonBuilder withSubjects(String subject) {
+        this.subjects = SampleDataUtil.getSubjectSet(subject);
         return this;
     }
 

--- a/src/test/java/seedu/tutor/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/tutor/testutil/TypicalPersons.java
@@ -27,14 +27,14 @@ public class TypicalPersons {
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253")
             .withTags("friends")
-            .withSubject("math")
+            .withSubjects("math")
             .withRelations("Elle Meyer/Alice Pauline/mother/child").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
             .withTags("owesMoney", "friends")
             .withRelations("Elle Meyer/Benson Meier/mother/child")
-            .withSubject("math")
+            .withSubjects("math")
             .build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").build();


### PR DESCRIPTION
Change subject to be a hash set instead of a string

Fix bug relating to subject taking up a new line even if no subject was entered

Update UI for subject

Edit add and edit functionality to accommodate new subject field

Update testcases for persons

Closes #95 
