### PR TITLE
DeleteSequenceDiagram update

### DIFF
--- a/docs/diagrams/DeleteSequenceDiagram.puml
+++ b/docs/diagrams/DeleteSequenceDiagram.puml
@@ -8,6 +8,7 @@ participant ":TutorMapParser" as TutorMapParser LOGIC_COLOR
 participant ":DeleteCommandParser" as DeleteCommandParser LOGIC_COLOR
 participant "d:DeleteCommand" as DeleteCommand LOGIC_COLOR
 participant "r:CommandResult" as CommandResult LOGIC_COLOR
+participant "rc:RelateCommand" as RelateCommand LOGIC_COLOR
 end box
 
 box Model MODEL_COLOR_T1
@@ -48,6 +49,17 @@ deactivate TutorMapParser
 
 LogicManager -> DeleteCommand : execute(m)
 activate DeleteCommand
+
+create RelateCommand
+DeleteCommand -> RelateCommand
+activate RelateCommand
+RelateCommand --> DeleteCommand
+deactivate RelateCommand
+
+DeleteCommand -> RelateCommand : execute(m)
+activate RelateCommand
+RelateCommand --> DeleteCommand
+deactivate RelateCommand
 
 DeleteCommand -> Model : deletePerson(1)
 activate Model


### PR DESCRIPTION
This PR updates `DeleteSequenceDiagram` with the new calls to `RelateCommand`'s methods, as well as the renaming of classes from `AddressBook` to `TutorMap`