### PR TITLE
Improve Edit command of UserGuide.md

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -99,6 +99,7 @@ Command format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [s/SUBJECT] [t/TAG]
 Notes:
 * A person can have any number of tags (including 0)
 * A person can have any number of subjects (including 0)
+* Person fields are case-sensitive (e.g. `John Doe` and `john doe` are different names, `Math` and `math` are different subjects)
 
 Examples:
 * `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01`


### PR DESCRIPTION
Improve the clarity of Edit Command for users in the User Guide

Currently, there is no instruction on adding multiple subjects or tags using 'edit' command

Updates the user guide to include instructions to add multiple subjects or tags.
Adds a 'Tip' box on using Edit command to add on subjects or tags

Adds note to 'add' command that Person fields are case sensitive (ie John and john are different names, Math and math are different subjects)



Closes #120 