### PR TITLE
Change subject name

### DIFF
--- a/src/main/java/seedu/tutor/logic/Messages.java
+++ b/src/main/java/seedu/tutor/logic/Messages.java
@@ -14,7 +14,7 @@ import seedu.tutor.model.relation.Relation;
 public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
-    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =

--- a/src/main/java/seedu/tutor/logic/commands/ChangeSubjectCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/ChangeSubjectCommand.java
@@ -1,8 +1,6 @@
 package seedu.tutor.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.tutor.logic.parser.CliSyntax.PREFIX_NEW_SUBJECT;
-import static seedu.tutor.logic.parser.CliSyntax.PREFIX_OLD_SUBJECT;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -21,16 +19,6 @@ import seedu.tutor.model.person.Person;
  */
 public class ChangeSubjectCommand extends Command {
 
-    public static final String COMMAND_WORD = "changeSubject";
-
-    public static final String MESSAGE_USAGE = COMMAND_WORD + "Changes a particular subject across all person.\n"
-            + "Parameters: "
-            + "[" + PREFIX_OLD_SUBJECT + "OLD_SUBJECT] "
-            + "[" + PREFIX_NEW_SUBJECT + "NEW_NEW_SUBJECT]\n"
-            + "OLD_SUBJECT and NEW_SUBJECT should only contain alphanumerical symbols.\n"
-            + "Example: " + COMMAND_WORD + " "
-            + PREFIX_OLD_SUBJECT + "Math " + PREFIX_NEW_SUBJECT + "A-Math";
-
     private final Label oldSubject;
     private final Label newSubject;
     private final EditCommandParser parser = new EditCommandParser();
@@ -40,7 +28,7 @@ public class ChangeSubjectCommand extends Command {
      * @param oldSubject The name of the subject to be changed.
      * @param newSubject The name of the subject to be added.
      */
-    public ChangeSubjectCommand(Label oldSubject, Label newSubject) {
+    ChangeSubjectCommand(Label oldSubject, Label newSubject) throws CommandException {
         this.oldSubject = oldSubject;
         this.newSubject = newSubject;
     }

--- a/src/main/java/seedu/tutor/logic/commands/SubjectCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/SubjectCommand.java
@@ -1,22 +1,70 @@
 package seedu.tutor.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.tutor.logic.parser.CliSyntax.PREFIX_CHANGE_SUBJECT;
+
 import seedu.tutor.logic.commands.exceptions.CommandException;
 import seedu.tutor.model.Model;
+import seedu.tutor.model.label.Label;
 
-public class SubjectCommand extends Command{
+/**
+ * Changes subject field of a particular person or, change or delete a particular subject across all person
+ */
+public class SubjectCommand extends Command {
 
     public static final String COMMAND_WORD = "subject";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " edit subject/s for a particular person "
+            + "or delete a particular subject across all person "
+            + "or change a particular subject across all person.\n"
+            + "Parameters: "
+            + "[" + PREFIX_CHANGE_SUBJECT + "OLD_SUBJECT/NEW_SUBJECT]\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_CHANGE_SUBJECT + "Math/AddMath";
+
+    /**
+     * Types of SubjectCommand
+     */
     public enum SubjectCommandType {
-        ADD, DELETE, CHANGE
+        EDIT, DELETE, CHANGE
     }
 
-    public SubjectCommand(SubjectCommandType type, String args) {
+    private final SubjectCommandType type;
+    private final Label[] subjects;
 
+    /**
+     * Returns a SubjectCommand object that changes the subject fields.
+     * @param type Type of the SubjectCommand.
+     * @param subjects Subjects in Label type.
+     */
+    public SubjectCommand(SubjectCommandType type, Label[] subjects) {
+        this.type = type;
+        this.subjects = subjects;
+    }
+
+    private Command getCommand() throws CommandException {
+        switch (this.type) {
+
+        case CHANGE:
+            if (this.subjects.length != 2) {
+                throw new CommandException("Input error: there should only have two subjects");
+            }
+            return new ChangeSubjectCommand(subjects[0], subjects[1]);
+
+        case EDIT: return null;
+
+        case DELETE: return null;
+
+        default:
+            // should not reach here
+            return null;
+        }
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        return null;
+        Command command = this.getCommand();
+        requireNonNull(command);
+        return command.execute(model);
     }
 }

--- a/src/main/java/seedu/tutor/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/tutor/logic/parser/CliSyntax.java
@@ -18,7 +18,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_RELATE_ADD = new Prefix("a\\");
     public static final Prefix PREFIX_RELATE_DELETE = new Prefix("d\\");
 
-    // sub-ChangeSubjectCommand prefixes
-    public static final Prefix PREFIX_OLD_SUBJECT = new Prefix("o\\");
-    public static final Prefix PREFIX_NEW_SUBJECT = new Prefix("n\\");
+    // sub-SubjectCommand prefixes
+    public static final Prefix PREFIX_EDIT_SUBJECT = new Prefix("e\\");
+    public static final Prefix PREFIX_CHANGE_SUBJECT = new Prefix("c\\");
+    public static final Prefix PREFIX_DELETE_SUBJECT = PREFIX_RELATE_DELETE;
 }

--- a/src/main/java/seedu/tutor/logic/parser/SubjectCommandParser.java
+++ b/src/main/java/seedu/tutor/logic/parser/SubjectCommandParser.java
@@ -1,65 +1,57 @@
 package seedu.tutor.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.tutor.logic.Messages.MESSAGE_DUPLICATE_FIELDS;
 import static seedu.tutor.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.tutor.logic.parser.CliSyntax.PREFIX_NEW_SUBJECT;
-import static seedu.tutor.logic.parser.CliSyntax.PREFIX_OLD_SUBJECT;
+import static seedu.tutor.logic.parser.CliSyntax.PREFIX_CHANGE_SUBJECT;
+import static seedu.tutor.logic.parser.CliSyntax.PREFIX_DELETE_SUBJECT;
+import static seedu.tutor.logic.parser.CliSyntax.PREFIX_EDIT_SUBJECT;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import seedu.tutor.logic.commands.ChangeSubjectCommand;
+import seedu.tutor.logic.commands.SubjectCommand;
 import seedu.tutor.logic.parser.exceptions.ParseException;
 import seedu.tutor.model.label.Label;
 
 /**
- * Parses input arguments and returns a new ChangeSubjectCommand object
+ * Parses input arguments and returns a new SubjectCommand object
  */
-public class SubjectCommandParser implements Parser<ChangeSubjectCommand> {
+public class SubjectCommandParser implements Parser<SubjectCommand> {
 
-    private static final String SUBJECT_NAME_ERROR = "Subject name should be alphanumerical.";
+    private static final String SUBJECT_NAME_ERROR = "Subject name should be alphanumerical.\n";
 
     /**
-     * Parses the given {@code String} of arguments in the context of the ChangeSubjectCommand
-     * and returns a ChangeSubjectCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the SubjectCommand
+     * and returns a SubjectCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public ChangeSubjectCommand parse(String args) throws ParseException {
+    public SubjectCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NEW_SUBJECT, PREFIX_OLD_SUBJECT);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_EDIT_SUBJECT, PREFIX_CHANGE_SUBJECT,
+                PREFIX_DELETE_SUBJECT);
 
+        int argumentCount = argMultimap.getAllValues(PREFIX_CHANGE_SUBJECT).size()
+                + argMultimap.getAllValues(PREFIX_DELETE_SUBJECT).size()
+                + argMultimap.getAllValues(PREFIX_EDIT_SUBJECT).size();
 
-        // errors
-        if (argMultimap.getAllValues(PREFIX_NEW_SUBJECT).isEmpty()
-                || argMultimap.getAllValues(PREFIX_OLD_SUBJECT).isEmpty()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ChangeSubjectCommand.MESSAGE_USAGE));
+        if (argumentCount != 1) {
+            throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT + SubjectCommand.MESSAGE_USAGE);
         }
 
-        Set<String> oldSubject = new HashSet<>();
-        Set<String> newSubject = new HashSet<>();
-        if (!argMultimap.getAllValues(PREFIX_OLD_SUBJECT).isEmpty()) {
-            oldSubject.addAll(argMultimap.getAllValues(PREFIX_OLD_SUBJECT));
-        }
-        if (!argMultimap.getAllValues(PREFIX_NEW_SUBJECT).isEmpty()) {
-            newSubject.addAll(argMultimap.getAllValues(PREFIX_NEW_SUBJECT));
-        }
-
-        if (oldSubject.size() != 1 || newSubject.size() != 1) {
-            throw new ParseException(String.format(MESSAGE_DUPLICATE_FIELDS + ChangeSubjectCommand.MESSAGE_USAGE));
-        }
-
-        Set<Label> oldSubjectLabel;
-        Set<Label> newSubjectLabel;
-
-        try {
-            oldSubjectLabel = ParserUtil.parseLabel(oldSubject);
-            newSubjectLabel = ParserUtil.parseLabel(newSubject);
-        } catch (ParseException pe) {
-            throw new ParseException(SUBJECT_NAME_ERROR);
+        if (argMultimap.getValue(PREFIX_CHANGE_SUBJECT).isPresent()) {
+            String temp0 = argMultimap.getValue(PREFIX_CHANGE_SUBJECT).get();
+            String[] temp1 = temp0.split("/");
+            if (temp1.length != 2 || temp0.endsWith("/")) {
+                throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT + SubjectCommand.MESSAGE_USAGE);
+            }
+            Label[] labels = new Label[2];
+            try {
+                labels[0] = ParserUtil.parseTag(temp1[0]);
+                labels[1] = ParserUtil.parseTag(temp1[1]);
+            } catch (ParseException pe) {
+                throw new ParseException(SUBJECT_NAME_ERROR);
+            }
+            return new SubjectCommand(SubjectCommand.SubjectCommandType.CHANGE, labels);
         }
 
-        return new ChangeSubjectCommand((Label) oldSubjectLabel.toArray()[0], (Label) newSubjectLabel.toArray()[0]);
+        // should not reach here
+        return null;
     }
 }

--- a/src/main/java/seedu/tutor/logic/parser/TutorMapParser.java
+++ b/src/main/java/seedu/tutor/logic/parser/TutorMapParser.java
@@ -9,7 +9,6 @@ import java.util.regex.Pattern;
 
 import seedu.tutor.commons.core.LogsCenter;
 import seedu.tutor.logic.commands.AddCommand;
-import seedu.tutor.logic.commands.ChangeSubjectCommand;
 import seedu.tutor.logic.commands.ClearCommand;
 import seedu.tutor.logic.commands.Command;
 import seedu.tutor.logic.commands.DeleteCommand;


### PR DESCRIPTION
Closes #135 

add new command: "subject" along with prefix "c\\"
function: change a particular subject's name across all person
format: "subject c\SUBJECT1/SUBJECT2"
requirements: `SUBJECT1` must exist in some person, both `SUBJECT1` and `SUBJECT2` must be alphanumerical only
result: all person with `SUBJECT1` change to` SUBECJT2`