### PR TITLE
Standardise invalid command output format, and help output

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -180,7 +180,7 @@ Step 2. The user executes `delete 5` command to delete the 5th person in the Tut
 
 <puml src="diagrams/UndoRedoState1.puml" alt="UndoRedoState1" />
 
-Step 3. The user executes `add n/David …​` to add a new person. The `add` command also calls `Model#commitTutorMap()`, causing another modified TutorMap state to be saved into the `TutorMapStateList`.
+Step 3. The user executes `add n/David ...` to add a new person. The `add` command also calls `Model#commitTutorMap()`, causing another modified TutorMap state to be saved into the `TutorMapStateList`.
 
 <puml src="diagrams/UndoRedoState2.puml" alt="UndoRedoState2" />
 
@@ -228,7 +228,7 @@ Step 5. The user then decides to execute the command `list`. Commands that do no
 
 <puml src="diagrams/UndoRedoState4.puml" alt="UndoRedoState4" />
 
-Step 6. The user executes `clear`, which calls `Model#commitTutorMap()`. Since the `currentStatePointer` is not pointing at the end of the `tutorMapStateList`, all TutorMap states after the `currentStatePointer` will be purged. Reason: It no longer makes sense to redo the `add n/David …​` command. This is the behavior that most modern desktop applications follow.
+Step 6. The user executes `clear`, which calls `Model#commitTutorMap()`. Since the `currentStatePointer` is not pointing at the end of the `tutorMapStateList`, all TutorMap states after the `currentStatePointer` will be purged. Reason: It no longer makes sense to redo the `add n/David ...` command. This is the behavior that most modern desktop applications follow.
 
 <puml src="diagrams/UndoRedoState5.puml" alt="UndoRedoState5" />
 
@@ -286,15 +286,15 @@ by combining a visual interface with efficient CLI commands for quick data entry
 
 Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unlikely to have) - `*`
 
-| Priority | As a …​                                    | I want to …​                                            | So that I can…​                                                             |
-|----------|--------------------------------------------|---------------------------------------------------------|-----------------------------------------------------------------------------|
-| `* * *`  | new user                                   | see usage instructions                                  | refer to instructions when I forget how to use the App                      |
-| `* * *`  | new user                                   | see an initial help message                             | see how to get started with the App                                         |
-| `* * *`  | user                                       | delete a contact                                        | remove contacts that I no longer need                                       |
-| `* * *`  | user                                       | find a contact by name                                  | locate details of contact without having to go through the entire list      |
-| `* * *`  | user                                       | find other relevant contacts given a contact            | see others who are related to my contact if there is a need to contact them |
-| `* *`    | user                                       | be able to tag contacts                                 | view information relevant to this contact                                   |
-| `*`      | user with many persons in the contact book | sort persons by name                                    | locate a contact easily                                                     |
+| Priority | As a ...                                   | I want to ...                                | So that I can...                                                            |
+|----------|--------------------------------------------|----------------------------------------------|-----------------------------------------------------------------------------|
+| `* * *`  | new user                                   | see usage instructions                       | refer to instructions when I forget how to use the App                      |
+| `* * *`  | new user                                   | see an initial help message                  | see how to get started with the App                                         |
+| `* * *`  | user                                       | delete a contact                             | remove contacts that I no longer need                                       |
+| `* * *`  | user                                       | find a contact by name                       | locate details of contact without having to go through the entire list      |
+| `* * *`  | user                                       | find other relevant contacts given a contact | see others who are related to my contact if there is a need to contact them |
+| `* *`    | user                                       | be able to tag contacts                      | view information relevant to this contact                                   |
+| `*`      | user with many persons in the contact book | sort persons by name                         | locate a contact easily                                                     |
 
 *{More to be added}*
 
@@ -474,7 +474,7 @@ testers are expected to do more *exploratory* testing.
    1. Re-launch the app by double-clicking the jar file.<br>
        Expected: The most recent window size and location is retained.
 
-1. _{ more test cases …​ }_
+1. _{ more test cases ... }_
 
 ### Deleting a person
 
@@ -491,7 +491,7 @@ testers are expected to do more *exploratory* testing.
    1. Other incorrect delete commands to try: `delete`, `delete x`, `...` (where x is larger than the list size)<br>
       Expected: Similar to previous.
 
-1. _{ more test cases …​ }_
+1. _{ more test cases ... }_
 
 ### Saving data
 
@@ -499,4 +499,4 @@ testers are expected to do more *exploratory* testing.
 
    1. _{explain how to simulate a missing/corrupted file, and the expected behavior}_
 
-1. _{ more test cases …​ }_
+1. _{ more test cases ... }_

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -66,8 +66,8 @@ TutorMap offers you a simple way to stay organized without complex software. If 
 * Items in square brackets are optional.<br>
   e.g `n/NAME [t/TAG]` can be used as `n/John Doe t/friend` or as `n/John Doe`.
 
-* Items with `…`​ after them can be used multiple times including zero times.<br>
-  e.g. `[t/TAG]…​` can be used as ` ` (i.e. 0 times), `t/friend`, `t/friend t/family` etc.
+* Items with `...` after them can be used multiple times including zero times.<br>
+  e.g. `[t/TAG]...` can be used as ` ` (i.e. 0 times), `t/friend`, `t/friend t/family` etc.
 
 * Parameters can be in any order.<br>
   e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
@@ -91,11 +91,11 @@ Command format: `help`
 
 Adds a person to TutorMap.
 
-Command format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [s/SUBJECT] [t/TAG]…`
+Command format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [s/SUBJECT]... [t/TAG]...`
 
 Notes:
-* A person can have any number of tags (including 0)
 * A person can have any number of subjects (including 0)
+* A person can have any number of tags (including 0)
 * Person fields are case-sensitive (e.g. `John Doe` and `john doe` are different names, `Math` and `math` are different subjects)
 
 Examples:
@@ -113,16 +113,16 @@ Command format: `list`
 
 Edits an existing person in TutorMap.
 
-Command format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG] [s/SUBJECT]…​`
+Command format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/SUBJECT]... [t/TAG]...`
 
 Notes:
 * Edits the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, ...
 * Existing values will be updated to the input values.
-* When editing tags, the existing tags of the person will be removed i.e adding of tags is not cumulative.
 * When editing subjects, the existing subject of the person will be removed i.e adding of subject is not cumulative.
-* You can remove all the person’s tags by typing `t/` without specifying any tags after it.
+* When editing tags, the existing tags of the person will be removed i.e adding of tags is not cumulative.
 * You can remove the person's subject by typing `s/` without specifying any subject after it.
-* Typing `t/` or `s/` is only valid if there is at least one non-whitespace character after it. Inputs containing only spaces after `t/` or `s/` are invalid.
+* You can remove all the person’s tags by typing `t/` without specifying any tags after it.
+* Typing `s/` or `t/` is only valid if there is at least one non-whitespace character after it. Inputs containing only spaces after `t/` or `s/` are invalid.
 
 Examples:
 * `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
@@ -227,8 +227,9 @@ Simply typing `s/C` will match both Chemistry and Chinese subjects!
 
 Adds a relation between 2 specified people in TutorMap.
 
-Command format (adding relation): `relate a\NAME1/NAME2/RELATION1/RELATION2`  
-Command format (deleting relation): `relate d\NAME1/NAME2/RELATION1/RELATION2`
+Command format: `relate [a\RELATION]... [d\RELATION]...`
+
+`RELATION` format: `Person1/Person2/Relation-Name1/Relation-Name2`
 
 Notes: 
 * To add a relation, both names must exist.
@@ -255,7 +256,7 @@ Command format: `delete INDEX`
 Notes: 
 * Deletes the person at the specified `INDEX`.
 * The index refers to the index number shown in the displayed person list.
-* The index **must be a positive integer** 1, 2, 3, …​
+* The index **must be a positive integer** 1, 2, 3, ...
 
 Examples:
 * `list` followed by `delete 2` deletes the 2nd person in the tutor map.
@@ -306,13 +307,12 @@ Furthermore, certain edits can cause the TutorMap to behave in unexpected ways (
 
 Action     | Format, Examples
 -----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-**Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG] [s/SUBJECT]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague`
+**Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [s/SUBJECT]... [t/TAG]...` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/relative's child s/math`
 **Clear**  | `clear`
 **Delete** | `delete INDEX`<br> e.g., `delete 3`
-**Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG] [s/SUBJECT]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
+**Edit**   | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/SUBJECT]... [t/TAG]...`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
 **Find (by name)**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`
 **Find (by relation)**   | `find r/KEYWORD` e.g., `find r/mother`, `find r/Alex Yeoh/Bernice Yu`
 **List**   | `list`
 **Help**   | `help`
-**Relate** (add) | `relate a\NAME1/NAME2/RELATION1/RELATION2`<br> e.g., `relate a\Teacher Alex/Bernice Yu/Teacher/Student`
-**Relate** (delete)| `relate d\NAME1/NAME2/RELATION1/RELATION2`<br> e.g., `relate d\Teacher Alex/Bernice Yu/Teacher/Student`
+**Relate** | `relate [a\RELATION]... [d\RELATION]...`<br> e.g., `relate a\Bernice Yu/Alex Yeoh/parent/child d\David Li/Charlotte Oliveiro/brother1/brother2`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -242,37 +242,36 @@ Simply typing `s/C` will match both Chemistry and Chinese subjects!
 
 ### <span id="subject-command"></span>Renaming, deleting, or editing subject(s): `subject`
 
-Renames a subject name across all persons, deletes subject(s) across all persons, or edits one person's subject field.
+Renames a subject name across all currently listed persons, deletes subject(s) across all currently listed persons, or edits one person's subject field.
 
 Command format: 
+* `subject [r\SUBJECT1/SUBJECT2]`
 * `subject [d\SUBJECT1/SUBJECT2/SUBJECT3/...]`  
 * `subject INDEX [e\SUBJECT1/SUBJECT2/SUBJECT3/...]`
-* `subject [r\SUBJECT1/SUBJECT2]`
 
 Notes:
-* All `SUBJECT` values must be alphanumeric only and non-empty.
+* All `SUBJECT` values must be alphanumeric (without whitespaces) only and non-empty.
+* For renaming a subject:
+    * `r\SUBJECT1/SUBJECT2` renames every instance of `SUBJECT1` to `SUBJECT2` across all currently listed persons' subject fields.
+    * Renaming a non-existing `SUBJECT` is allowed. `No subject renamed.` will be returned if no subject is renamed.
 * For deleting subject(s):
     * `d\SUBJECT1/SUBJECT2/SUBJECT3` deletes every instance of `SUBJECT1`, `SUBJECT2`, and `SUBJECT3` across all persons' subject fields.
-    * `d\` accepts any positive number of subjects.
+    * `d\` accepts any positive number of subjects. 
     * Deleting a non-existing `SUBJECT` is allowed. `No subject deleted.` will be returned if no subject is deleted.
 * For editing a person's subject field:
-    * `INDEX e\SUBJECT1/SUBJECT2/...` edits the `INDEX`-th shown person's subject field by toggling each listed subject.
-    * `Index` must be a positive integer.
+    * `INDEX e\SUBJECT1/SUBJECT2/...` edits the `INDEX`-th shown person's subject field by toggling each listed subject. This command provides functionality for adding and removing subjects in a single command.
+    * `INDEX` must be a positive integer.
     * Toggling means:
-        * an existing subject is removed;
-        * a missing subject is added.
+        * an existing subject is removed; and
+        * a non-existing subject is added.
     * `e\` accepts any positive number of subjects.
-    * This command may add and remove subjects in a single use.
-* For renaming a subject:
-    * `r\SUBJECT1/SUBJECT2` renames every instance of `SUBJECT1` to `SUBJECT2` across all persons' subject fields.
-    * Renaming a non-existing `SUBJECT` is allowed. `No subject renamed.` will be returned if no subject is renamed.
 
-Example:
-* `subject d\Mathematics/Mandrin`
-* `subject d\Biology/Physic/Chemistry/History/Art`
-* `subject 1 e\Maths/Biology`
-* `subject 2 e\Physic/Chemistry/History/Art`
+Examples:
 * `subject r\Maths/Mathematics`
+* `subject d\Mathematics/Mandarin`
+* `subject d\Biology/Physics/Chemistry/History/Art`
+* `subject 1 e\Maths/Biology`
+* `subject 2 e\Physics/Chemistry/History/Art`
 
 ### <span id="deleting-person"></span>Deleting a person : `delete`
 
@@ -345,7 +344,7 @@ Action     | Format, Examples
 **List**   | `list`
 **Help**   | `help`
 **Relate** | `relate [a\RELATION]... [d\RELATION]...`<br> e.g., `relate a\Bernice Yu/Alex Yeoh/parent/child d\David Li/Charlotte Oliveiro/brother1/brother2`
-**Subject** (delete)|`subject [d\SUBJECT1/SUBJECT2/SUBJECT3/...]`<br> e.g., `subject d\Art/History/Mandrin/English`
-**Subject** (edit)|`subject INDEX [e\SUBJECT1/SUBJECT2/SUBJECT3/...]`<br> e.g., `subject 1 e\Art/History/Mandrin/English`
-**Subject** (rename)|`subject [r\SUBJECT1/SUBJECT2]`<br> e.g., `subject r\Math/Mathematic`
+**Subject** (rename)|`subject [r\SUBJECT1/SUBJECT2]`<br> e.g., `subject r\Math/Mathematics`
+**Subject** (delete)|`subject [d\SUBJECT1/SUBJECT2/SUBJECT3/...]`<br> e.g., `subject d\Art/History/Mandarin/English`
+**Subject** (edit)|`subject INDEX [e\SUBJECT1/SUBJECT2/SUBJECT3/...]`<br> e.g., `subject 1 e\Art/History/Mandarin/English`
 

--- a/src/main/java/seedu/tutor/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/AddCommand.java
@@ -21,14 +21,16 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book.\n"
+
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
-            + PREFIX_SUBJECT + "SUBJECT "
+            + "[" + PREFIX_SUBJECT + "SUBJECT]... "
             + "[" + PREFIX_TAG + "TAG]...\n"
+
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
@@ -36,7 +38,11 @@ public class AddCommand extends Command {
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
             + PREFIX_SUBJECT + "Math "
             + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney";
+            + PREFIX_TAG + "owesMoney\n"
+
+            + "Notes: \n"
+            + "- " + PREFIX_TAG + ", " + PREFIX_SUBJECT + " are optional.\n"
+            + "- " + PREFIX_TAG + ", " + PREFIX_SUBJECT + " can be used once or multiple times.";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";

--- a/src/main/java/seedu/tutor/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/DeleteCommand.java
@@ -23,8 +23,11 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person identified by the index number used in the displayed person list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + "Parameters: INDEX\n"
+            + "Example: " + COMMAND_WORD + " 1\n"
+
+            + "Notes: \n"
+            + "⚠ INDEX must be a positive integer.";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
 

--- a/src/main/java/seedu/tutor/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/EditCommand.java
@@ -55,7 +55,8 @@ public class EditCommand extends Command {
 
             + "Notes: \n"
             + "⚠ INDEX must be a positive integer.\n"
-            + "- " + PREFIX_NAME + ", " + PREFIX_PHONE + ", " + PREFIX_EMAIL + ", " + PREFIX_ADDRESS + ", " + PREFIX_TAG + ", " + PREFIX_SUBJECT + "are optional, "
+            + "- " + PREFIX_NAME + ", " + PREFIX_PHONE + ", " + PREFIX_EMAIL + ", "
+            + PREFIX_ADDRESS + ", " + PREFIX_TAG + ", " + PREFIX_SUBJECT + "are optional, "
             + "but at least one must be present.\n"
             + "- " + PREFIX_TAG + ", " + PREFIX_SUBJECT + " can be used once or multiple times.";
 

--- a/src/main/java/seedu/tutor/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/EditCommand.java
@@ -46,8 +46,8 @@ public class EditCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + PREFIX_TAG + "TAG]... "
-            + "[" + PREFIX_SUBJECT + "SUBJECT]...\n"
+            + "[" + PREFIX_SUBJECT + "SUBJECT]..."
+            + "[" + PREFIX_TAG + "TAG]...\n"
 
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
@@ -56,9 +56,9 @@ public class EditCommand extends Command {
             + "Notes: \n"
             + "⚠ INDEX must be a positive integer.\n"
             + "- " + PREFIX_NAME + ", " + PREFIX_PHONE + ", " + PREFIX_EMAIL + ", "
-            + PREFIX_ADDRESS + ", " + PREFIX_TAG + ", " + PREFIX_SUBJECT + "are optional, "
+            + PREFIX_ADDRESS + ", " + PREFIX_SUBJECT + ", " + PREFIX_TAG + "are optional, "
             + "but at least one must be present.\n"
-            + "- " + PREFIX_TAG + ", " + PREFIX_SUBJECT + " can be used once or multiple times.";
+            + "- " + PREFIX_SUBJECT + ", " + PREFIX_TAG + " can be used once or multiple times.";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/tutor/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/EditCommand.java
@@ -40,16 +40,24 @@ public class EditCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
             + "by the index number used in the displayed person list. "
             + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer) "
+
+            + "Parameters: INDEX "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + PREFIX_TAG + "TAG] "
+            + "[" + PREFIX_TAG + "TAG]... "
             + "[" + PREFIX_SUBJECT + "SUBJECT]...\n"
+
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
-            + PREFIX_EMAIL + "johndoe@example.com";
+            + PREFIX_EMAIL + "johndoe@example.com\n"
+
+            + "Notes: \n"
+            + "⚠ INDEX must be a positive integer.\n"
+            + "- " + PREFIX_NAME + ", " + PREFIX_PHONE + ", " + PREFIX_EMAIL + ", " + PREFIX_ADDRESS + ", " + PREFIX_TAG + ", " + PREFIX_SUBJECT + "are optional, "
+            + "but at least one must be present.\n"
+            + "- " + PREFIX_TAG + ", " + PREFIX_SUBJECT + " can be used once or multiple times.";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/tutor/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/HelpCommand.java
@@ -21,7 +21,7 @@ public class HelpCommand extends Command {
             + "clear\n\n"
             + "find KEYWORD [MORE KEYWORDS] e.g., find James Jake\n\n"
             + "help\n\n"
-            + "edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]... [s/SUBJECT]...\n"
+            + "edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/SUBJECT]... [t/TAG]...\n"
             + "e.g., edit 2 n/James Lee e/jameslee@example.com\n\n"
             + "relate [a\\RELATION]... [d\\RELATION]...\n"
             + "e.g., relate a\\James Lee Junior/James Lee/Son/Father";

--- a/src/main/java/seedu/tutor/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/HelpCommand.java
@@ -13,20 +13,18 @@ public class HelpCommand extends Command {
             + "Example: " + COMMAND_WORD;
 
     public static final String SHOWING_HELP_MESSAGE = "Available commands:\n"
-            + "add n/NAME p/PHONE e/EMAIL a/ADDRESS [s/SUBJECT]\n"
-            + "e.g., add n/James Ho p/22224444 e/jamesho@example.com"
-            + "a/123, Clementi Rd, 1234665 t/friend t/colleague s/math\n"
-            + "delete INDEX e.g., delete 3 \n"
-            + "list \n"
-            + "clear \n"
-            + "find KEYWORD [MORE KEYWORDS] e.g., find James Jake \n"
-            + "help \n"
-            + "edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG] [s/SUBJECT]...\n"
-            + "e.g., edit 2 n/James Lee e/jameslee@example.com \n"
-            + "relate a\\name1/name2/relationship1/relationship2 \n"
-            + "e.g., relate a\\James Lee Junior/James Lee/Son/Father\n"
-            + "relate d\\name1/name2/relationship1/relationship2 \n"
-            + "e.g., relate d\\James Lee Junior/James Lee/Son/Father";
+            + "add n/NAME p/PHONE e/EMAIL a/ADDRESS [s/SUBJECT]... [t/TAG]...\n"
+            + "e.g., add n/James Ho p/91234567 e/jamesho@example.com "
+            + "a/123, Clementi Rd, 1234665 s/math t/friend t/colleague\n\n"
+            + "delete INDEX e.g., delete 3 \n\n"
+            + "list\n\n"
+            + "clear\n\n"
+            + "find KEYWORD [MORE KEYWORDS] e.g., find James Jake\n\n"
+            + "help\n\n"
+            + "edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]... [s/SUBJECT]...\n"
+            + "e.g., edit 2 n/James Lee e/jameslee@example.com\n\n"
+            + "relate [a\\RELATION]... [d\\RELATION]...\n"
+            + "e.g., relate a\\James Lee Junior/James Lee/Son/Father";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/tutor/logic/commands/RelateCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/RelateCommand.java
@@ -3,7 +3,6 @@ package seedu.tutor.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.tutor.logic.parser.CliSyntax.PREFIX_RELATE_ADD;
 import static seedu.tutor.logic.parser.CliSyntax.PREFIX_RELATE_DELETE;
-import static seedu.tutor.logic.parser.CliSyntax.PREFIX_SUBJECT;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -47,7 +46,8 @@ public class RelateCommand extends Command {
             + "Notes: \n"
             + "⚠ " + PREFIX_RELATE_ADD + ", " + PREFIX_RELATE_DELETE + " uses backslash (\\), not forward slash (/).\n"
             + "- RELATION format: [Person1/Person2/Relation-Name1/Relation-Name2]\n"
-            + "- " + PREFIX_RELATE_ADD + ", " + PREFIX_RELATE_DELETE + "are optional, but at least one must be present.\n"
+            + "- " + PREFIX_RELATE_ADD + ", " + PREFIX_RELATE_DELETE
+            + "are optional, but at least one must be present.\n"
             + "- " + PREFIX_RELATE_ADD + ", " + PREFIX_RELATE_DELETE + " can be used once or multiple times.";
 
     private final Set<Relation> relationsToAdd;

--- a/src/main/java/seedu/tutor/logic/commands/RelateCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/RelateCommand.java
@@ -3,6 +3,7 @@ package seedu.tutor.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.tutor.logic.parser.CliSyntax.PREFIX_RELATE_ADD;
 import static seedu.tutor.logic.parser.CliSyntax.PREFIX_RELATE_DELETE;
+import static seedu.tutor.logic.parser.CliSyntax.PREFIX_SUBJECT;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -35,14 +36,19 @@ public class RelateCommand extends Command {
 
     public static final String COMMAND_WORD = "relate";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Add or delete a relation between two person.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds or deletes a relation between two persons.\n"
             + "Parameters: "
-            + "[" + PREFIX_RELATE_ADD + "RELATION] "
-            + "or "
-            + "[" + PREFIX_RELATE_DELETE + "RELATION]\n"
-            + "RELATION format: [Person1/Person2/Relation Name1/Relation Name2]\n"
+            + "[" + PREFIX_RELATE_ADD + "RELATION]... "
+            + "[" + PREFIX_RELATE_DELETE + "RELATION]...\n"
+
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_RELATE_ADD + "Linq/Keiran/teammate/teammate ";
+            + PREFIX_RELATE_ADD + "Linq/Keiran/teammate/teammate\n"
+
+            + "Notes: \n"
+            + "⚠ " + PREFIX_RELATE_ADD + ", " + PREFIX_RELATE_DELETE + " uses backslash (\\), not forward slash (/).\n"
+            + "- RELATION format: [Person1/Person2/Relation-Name1/Relation-Name2]\n"
+            + "- " + PREFIX_RELATE_ADD + ", " + PREFIX_RELATE_DELETE + "are optional, but at least one must be present.\n"
+            + "- " + PREFIX_RELATE_ADD + ", " + PREFIX_RELATE_DELETE + " can be used once or multiple times.";
 
     private final Set<Relation> relationsToAdd;
     private final Set<Relation> relationsToDelete;

--- a/src/main/java/seedu/tutor/logic/commands/SubjectCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/SubjectCommand.java
@@ -17,21 +17,24 @@ public class SubjectCommand extends Command {
 
     public static final String COMMAND_WORD = "subject";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Delete subject(s) across all person "
-            + "or edit subject(s) for a particular person "
-            + "or rename a particular subject across all person.\n"
-            + "Parameters: "
-            + "[" + PREFIX_SUBJECT_DELETE + "SUBJECT1/SUBJECT2/SUBJECT3/...] "
-            + "or "
-            + "INDEX (must be a positive integer) + [" + PREFIX_SUBJECT_EDIT + "SUBJECT1/SUBJECT2/SUBJECT3/...] "
-            + "or "
-            + "[" + PREFIX_SUBJECT_RENAME + "OLD_SUBJECT/NEW_SUBJECT]\n"
-            + "Example:\n"
-            + COMMAND_WORD + " " + PREFIX_SUBJECT_DELETE + "Math/Science/Chinese/History\n"
-            + COMMAND_WORD + " " + PREFIX_SUBJECT_DELETE + "Math/Biology\n"
-            + COMMAND_WORD + " 1 " + PREFIX_SUBJECT_EDIT + "Math/Science/Chinese/History\n"
-            + COMMAND_WORD + " 2 " + PREFIX_SUBJECT_EDIT + "Physic/Chemistry"
-            + COMMAND_WORD + " " + PREFIX_SUBJECT_RENAME + "Math/AddMath\n";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Renames a subject name across all currently listed persons, "
+            + "deletes subject(s) across all currently listed persons, or edits one person's subject field.\n"
+
+            + "Parameters: only one out of the following:\n"
+            + "- [" + PREFIX_SUBJECT_RENAME + "OLD_SUBJECT/NEW_SUBJECT]\n"
+            + "- [" + PREFIX_SUBJECT_DELETE + "SUBJECT1/SUBJECT2/SUBJECT3/...]\n"
+            + "- INDEX + [" + PREFIX_SUBJECT_EDIT + "SUBJECT1/SUBJECT2/SUBJECT3/...]\n"
+
+            + "Examples:\n"
+            + "- " + COMMAND_WORD + " " + PREFIX_SUBJECT_RENAME + "Maths/Mathematics\n"
+            + "- " + COMMAND_WORD + " " + PREFIX_SUBJECT_DELETE + "Mathematics/Mandarin\n"
+            + "- " + COMMAND_WORD + " " + PREFIX_SUBJECT_DELETE + "Biology/Physics/Chemistry/History/Art\n"
+            + "- " + COMMAND_WORD + " 1 " + PREFIX_SUBJECT_EDIT + "Math/Science/Chinese/History\n"
+            + "- " + COMMAND_WORD + " 2 " + PREFIX_SUBJECT_EDIT + "Physics/Chemistry/History/Art\n"
+
+            + "Notes: \n"
+            + "⚠ INDEX must be a positive integer."
+            + "- For d\\, e\\, there can be one or multiple subjects.";
 
     /**
      * Types of SubjectCommand

--- a/src/main/java/seedu/tutor/logic/commands/SubjectCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/SubjectCommand.java
@@ -17,7 +17,8 @@ public class SubjectCommand extends Command {
 
     public static final String COMMAND_WORD = "subject";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Renames a subject name across all currently listed persons, "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Renames a subject name "
+            + "across all currently listed persons, "
             + "deletes subject(s) across all currently listed persons, or edits one person's subject field.\n"
 
             + "Parameters: only one out of the following:\n"


### PR DESCRIPTION
Purely cosmestic, no feature changes.
- Standardised and improve clarity of invalid command outputs (except `find`, to be done in #164).
- Update help output and UG with latest command formats.

Closes #186, closes #187, closes #188