### PR TITLE
Add confirmation before clear command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -48,7 +48,7 @@ TutorMap offers you a simple way to stay organized without complex software. If 
 
     * `delete 3` : Deletes the 3rd contact shown in the current list.
 
-    * `clear` : Deletes all contacts.
+    * `clear confirm` : Deletes all contacts.
 
     * `exit` : Exits the app.
 
@@ -72,7 +72,7 @@ TutorMap offers you a simple way to stay organized without complex software. If 
 * Parameters can be in any order.<br>
   e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
 
-* Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
+* Extraneous parameters for commands that do not take in parameters (such as `help`, `list` and `exit`) will be ignored.<br>
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
 
 * If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
@@ -263,7 +263,7 @@ Examples:
 
 ### <span id="clearing-entries"></span>Clearing all entries : `clear`
 
-Clears all entries from the tutor map.
+Clears all entries from the tutor map. As a safety measure, `clear` returns the command usage information, and does not actually clear the output.
 
 Command format: `clear confirm`
 
@@ -309,7 +309,7 @@ Furthermore, certain edits can cause the TutorMap to behave in unexpected ways (
 Action     | Format, Examples
 -----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 **Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG] [s/SUBJECT]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague`
-**Clear**  | `clear`
+**Clear**  | `clear confirm`
 **Delete** | `delete INDEX`<br> e.g., `delete 3`
 **Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG] [s/SUBJECT]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
 **Find (by name)**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -265,7 +265,9 @@ Examples:
 
 Clears all entries from the tutor map.
 
-Command format: `clear`
+Command format: `clear confirm`
+
+**Caution**: This action is irreversible! Use `clear confirm` to clear. Any parameters other than `confirm` will abort the clearing.
 
 ### <span id="exiting-program"></span>Exiting the program : `exit`
 

--- a/src/main/java/seedu/tutor/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/ClearCommand.java
@@ -11,8 +11,17 @@ import seedu.tutor.model.TutorMap;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Clears the entire list.\n"
+            + "Parameters: confirm\n"
+            + "Example: " + COMMAND_WORD + " confirm\n"
+
+            + "Notes: \n"
+            + "⚠ This action is irreversible! Type \"clear confirm\" to proceed with clearing.";
+
+
+    public static final String MESSAGE_SUCCESS = "TutorMap has been cleared!";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/tutor/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/HelpCommand.java
@@ -16,16 +16,17 @@ public class HelpCommand extends Command {
             + "add n/NAME p/PHONE e/EMAIL a/ADDRESS [s/SUBJECT]\n"
             + "e.g., add n/James Ho p/22224444 e/jamesho@example.com"
             + "a/123, Clementi Rd, 1234665 t/friend t/colleague s/math\n"
-            + "delete INDEX e.g., delete 3 \n"
-            + "list \n"
-            + "clear \n"
-            + "find KEYWORD [MORE KEYWORDS] e.g., find James Jake \n"
+            + "delete INDEX e.g., delete 3l\n"
+            + "list\n"
+            + "clear\n"
+            + "eg. clear confirm\n"
+            + "find KEYWORD [MORE KEYWORDS] e.g., find James Jake\n"
             + "help \n"
             + "edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG] [s/SUBJECT]...\n"
-            + "e.g., edit 2 n/James Lee e/jameslee@example.com \n"
+            + "e.g., edit 2 n/James Lee e/jameslee@example.com\n"
             + "relate a\\name1/name2/relationship1/relationship2 \n"
             + "e.g., relate a\\James Lee Junior/James Lee/Son/Father\n"
-            + "relate d\\name1/name2/relationship1/relationship2 \n"
+            + "relate d\\name1/name2/relationship1/relationship2\n"
             + "e.g., relate d\\James Lee Junior/James Lee/Son/Father";
 
     @Override

--- a/src/main/java/seedu/tutor/logic/parser/ClearCommandParser.java
+++ b/src/main/java/seedu/tutor/logic/parser/ClearCommandParser.java
@@ -1,0 +1,26 @@
+package seedu.tutor.logic.parser;
+
+import static seedu.tutor.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.tutor.logic.commands.ClearCommand;
+import seedu.tutor.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ClearCommand object
+ */
+public class ClearCommandParser implements Parser<ClearCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ClearCommand
+     * and returns a ClearCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ClearCommand parse(String args) throws ParseException {
+        if (!args.strip().equals("confirm")) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ClearCommand.MESSAGE_USAGE));
+        } else {
+            return new ClearCommand();
+        }
+    }
+}

--- a/src/main/java/seedu/tutor/logic/parser/TutorMapParser.java
+++ b/src/main/java/seedu/tutor/logic/parser/TutorMapParser.java
@@ -64,7 +64,7 @@ public class TutorMapParser {
             return new DeleteCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
+            return new ClearCommandParser().parse(arguments);
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);

--- a/src/test/java/seedu/tutor/logic/parser/TutorMapParserTest.java
+++ b/src/test/java/seedu/tutor/logic/parser/TutorMapParserTest.java
@@ -36,8 +36,7 @@ public class TutorMapParserTest {
 
     @Test
     public void parseCommand_clear() throws Exception {
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " confirm") instanceof ClearCommand);
     }
 
     @Test


### PR DESCRIPTION
Updated clear command to require confirmation. `clear` on its own is an invalid command. Only the exact string `clear confirm` will execute the command. `Confirm`, `CONFIRM` etc will not execute.

This prevents users from accidentally deleting their contacts while testing out the various commands.

Also updated help command and UG to reflect new feature.

Closes #190.