### PR TITLE
Update help to help by command

### DIFF
--- a/src/main/java/seedu/tutor/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/ExitCommand.java
@@ -9,6 +9,9 @@ public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Exits the program.";
+
     public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
 
     @Override

--- a/src/main/java/seedu/tutor/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/HelpCommand.java
@@ -12,25 +12,71 @@ public class HelpCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
             + "Example: " + COMMAND_WORD;
 
-    public static final String SHOWING_HELP_MESSAGE = "Available commands:\n"
-            + "add n/NAME p/PHONE e/EMAIL a/ADDRESS [s/SUBJECT]\n"
-            + "e.g., add n/James Ho p/22224444 e/jamesho@example.com"
-            + "a/123, Clementi Rd, 1234665 t/friend t/colleague s/math\n"
-            + "delete INDEX e.g., delete 3l\n"
-            + "list\n"
-            + "clear\n"
-            + "eg. clear confirm\n"
-            + "find KEYWORD [MORE KEYWORDS] e.g., find James Jake\n"
-            + "help \n"
-            + "edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG] [s/SUBJECT]...\n"
-            + "e.g., edit 2 n/James Lee e/jameslee@example.com\n"
-            + "relate a\\name1/name2/relationship1/relationship2 \n"
-            + "e.g., relate a\\James Lee Junior/James Lee/Son/Father\n"
-            + "relate d\\name1/name2/relationship1/relationship2\n"
-            + "e.g., relate d\\James Lee Junior/James Lee/Son/Father";
+    public static final String DEFAULT_HELP_MESSAGE = "Available commands:"
+            + "(type `help [COMMAND]` to see details of each command, eg. `help add`):\n"
+            + "- list\n"
+            + "- add\n"
+            + "- edit\n"
+            + "- delete\n"
+            + "- clear\n"
+            + "- relate\n"
+            + "- subject\n"
+            + "- find \n"
+            + "- exit \n";
+
+    private final String commandString;
+
+    private String helpMessage;
+
+    public HelpCommand(String commandString) {
+        this.commandString = commandString.trim().toLowerCase();
+    }
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+
+        switch (commandString) {
+
+        case AddCommand.COMMAND_WORD:
+            helpMessage = AddCommand.MESSAGE_USAGE;
+            break;
+
+        case EditCommand.COMMAND_WORD:
+            helpMessage = EditCommand.MESSAGE_USAGE;
+            break;
+
+        case DeleteCommand.COMMAND_WORD:
+            helpMessage = DeleteCommand.MESSAGE_USAGE;
+            break;
+
+        case ClearCommand.COMMAND_WORD:
+            helpMessage = ClearCommand.MESSAGE_USAGE;
+            break;
+
+        case FindCommand.COMMAND_WORD:
+            helpMessage = FindCommand.MESSAGE_USAGE;
+            break;
+
+        case ListCommand.COMMAND_WORD:
+            helpMessage = ListCommand.MESSAGE_USAGE;
+            break;
+
+        case ExitCommand.COMMAND_WORD:
+            helpMessage = ExitCommand.MESSAGE_USAGE;
+            break;
+
+        case RelateCommand.COMMAND_WORD:
+            helpMessage = RelateCommand.MESSAGE_USAGE;
+            break;
+
+        case SubjectCommand.COMMAND_WORD:
+            helpMessage = SubjectCommand.MESSAGE_USAGE;
+            break;
+
+        default:
+            helpMessage = DEFAULT_HELP_MESSAGE;
+        }
+
+        return new CommandResult(helpMessage, true, false);
     }
 }

--- a/src/main/java/seedu/tutor/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/ListCommand.java
@@ -12,6 +12,10 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Shows a list of all persons in TutorMap.\n"
+            + "Example: " + COMMAND_WORD;
+
     public static final String MESSAGE_SUCCESS = "Listed all persons";
 
 

--- a/src/main/java/seedu/tutor/logic/parser/TutorMapParser.java
+++ b/src/main/java/seedu/tutor/logic/parser/TutorMapParser.java
@@ -77,7 +77,7 @@ public class TutorMapParser {
             return new ExitCommand();
 
         case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
+            return new HelpCommand(arguments);
 
         case RelateCommand.COMMAND_WORD:
             return new RelateCommandParser().parse(arguments);

--- a/src/test/java/seedu/tutor/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/tutor/logic/commands/HelpCommandTest.java
@@ -1,7 +1,7 @@
 package seedu.tutor.logic.commands;
 
 import static seedu.tutor.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.tutor.logic.commands.HelpCommand.SHOWING_HELP_MESSAGE;
+import static seedu.tutor.logic.commands.HelpCommand.DEFAULT_HELP_MESSAGE;
 
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +14,7 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
-        assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
+        CommandResult expectedCommandResult = new CommandResult(DEFAULT_HELP_MESSAGE, true, false);
+        assertCommandSuccess(new HelpCommand(""), model, expectedCommandResult, expectedModel);
     }
 }


### PR DESCRIPTION
`help` displays a list of commands (without any explanations).
`help add` displays usage message for `add`, and respectively for all other commands. Whitespace is trimmed.
Any other arguments that isn't a valid command returns the default `help` command output. 

Closes #196.