### PR TITLE
Update Phone field to include country code

### DIFF
--- a/src/main/java/seedu/tutor/model/person/Phone.java
+++ b/src/main/java/seedu/tutor/model/person/Phone.java
@@ -11,8 +11,9 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+            "Phone numbers should contain only digits and be at least 3 digits long, "
+                    + "optionally prefixed with a parenthesized country code";
+    public static final String VALIDATION_REGEX = "^(\\(\\+?[\\d-]*\\d[\\d-]*\\))?\\d{3,}$";
     public final String value;
 
     /**

--- a/src/test/java/seedu/tutor/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/tutor/logic/parser/ParserUtilTest.java
@@ -30,6 +30,7 @@ public class ParserUtilTest {
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
+    private static final String VALID_PHONE_WITH_PREFIX = "(+65)12345678";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_SUBJECT_1 = "Physics";
@@ -93,6 +94,11 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parsePhone_shortValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parsePhone("12"));
+    }
+
+    @Test
     public void parsePhone_validValueWithoutWhitespace_returnsPhone() throws Exception {
         Phone expectedPhone = new Phone(VALID_PHONE);
         assertEquals(expectedPhone, ParserUtil.parsePhone(VALID_PHONE));
@@ -103,6 +109,12 @@ public class ParserUtilTest {
         String phoneWithWhitespace = WHITESPACE + VALID_PHONE + WHITESPACE;
         Phone expectedPhone = new Phone(VALID_PHONE);
         assertEquals(expectedPhone, ParserUtil.parsePhone(phoneWithWhitespace));
+    }
+
+    @Test
+    public void parsePhone_validValueWithParenthesizedPrefix_returnsPhone() throws Exception {
+        Phone expectedPhone = new Phone(VALID_PHONE_WITH_PREFIX);
+        assertEquals(expectedPhone, ParserUtil.parsePhone(VALID_PHONE_WITH_PREFIX));
     }
 
     @Test

--- a/src/test/java/seedu/tutor/model/person/PhoneTest.java
+++ b/src/test/java/seedu/tutor/model/person/PhoneTest.java
@@ -27,15 +27,19 @@ public class PhoneTest {
         // invalid phone numbers
         assertFalse(Phone.isValidPhone("")); // empty string
         assertFalse(Phone.isValidPhone(" ")); // spaces only
-        assertFalse(Phone.isValidPhone("91")); // less than 3 numbers
+        assertFalse(Phone.isValidPhone("12")); // fewer than 3 digits
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
+        assertFalse(Phone.isValidPhone("(+65)")); // missing digits after prefix
+        assertFalse(Phone.isValidPhone("(+65)12")); // fewer than 3 digits after prefix
 
         // valid phone numbers
         assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
         assertTrue(Phone.isValidPhone("93121534"));
         assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertTrue(Phone.isValidPhone("(+65)12345678")); // parenthesized country code prefix
+        assertTrue(Phone.isValidPhone("(65-12)3456")); // digits and hyphens inside prefix
     }
 
     @Test


### PR DESCRIPTION
Edits string validation: Allows for paranthesis followed by numeric characters, and + or - symbol within the paranthesis. Restriction of at least 3 digits (after paranthesis) is kept. There should be not whitespace between closing paranthesis and digits

Closes #195 