### PR TITLE
Add Command Error Message: Reflect Subject as Optional

### DIFF
--- a/src/main/java/seedu/tutor/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/AddCommand.java
@@ -27,7 +27,7 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
-            + PREFIX_SUBJECT + "SUBJECT "
+            + "[" + PREFIX_SUBJECT + "SUBJECT] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "


### PR DESCRIPTION
Update the invalid add command input message to reflect subject as optional. Currently there are no "[ ]" around the subject field

Closes #180 