### PR TITLE
Bug Fixes,  DG Planned Enhancements, DG User Stories

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -287,9 +287,9 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 | `* * *`  | new user                                   | see usage instructions                       | refer to instructions when I forget how to use the App                      |
 | `* * *`  | new user                                   | see an initial help message                  | see how to get started with the App                                         |
 | `* * *`  | user                                       | delete a contact                             | remove contacts that I no longer need                                       |
-| `* * *`  | user                                       | find a contact by name                       | locate details of contact without having to go through the entire list      |
-| `* * *`  | user                                       | find other relevant contacts given a contact | see others who are related to my contact if there is a need to contact them |
-| `* *`    | user                                       | add relation between two contacts            | keep track of how they are connected                                        |
+| `* * *`  | user                                       | find a contact by different fields           | locate details of contact without having to go through the entire list      |
+| `* * *`  | user                                       | add relation between two contacts            | keep track of how they are connected                                        |
+| `* *`    | user                                       | find other relevant contacts given a contact | see others who are related to my contact if there is a need to contact them |
 | `* *`    | user                                       | edit the subject field of a contact          | keep the contact's subject information up to date                           |
 | `* *`    | user                                       | rename a subject across the contacts         | correct or standardize subject names easily                                 |
 | `* *`    | user                                       | delete a subject across the contacts         | remove outdated or unnecessary subject records                              |

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -654,3 +654,17 @@ testers are expected to do more *exploratory* testing.
    1. If your changes to the data file makes its format invalid, TutorMap will discard all data and start with an empty data file at the next run.  Hence, it is recommended to take a backup of the file before editing it.
    2. TutorMap does not erase all your data in case an invalid relation exists that still conforms to the relation format `name1/name2/relation1/relation2`. However, it may behave in unexpected ways.
 
+--------------------------------------------------------------------------------------------------------------------
+
+## **Appendix: Planned Enhancements**
+
+Team size: 5
+
+1. **Make `name` field more permissible.** The current `name` field only allows alphanumeric and whitespace characters, which might prevent the addition of real names like `O'Brien`. We plan to allow non-alphanumeric, as well as non-English characters.
+2. **Make `subject` field more permissible.** The current `subject` field only allows alphanumeric characters, which might prevent the addition of subjects like `H2 Math`. We plan to allow non-alphanumeric, as well as non-English characters.
+3. **Make `tag` field more permissible.** The current `tag` field only allows alphanumeric characters, which might prevent the addition of tags like `consult-based tutoring`. We plan to allow non-alphanumeric, as well as non-English characters.
+4. **Trim `name` fields with multiple whitespace between words.** The current `name` field accepts names with different internal whitespace as separate names, which usually does not appear in regular names and are mostly likely typos. We plan to trim multiple whitespace into 1 whitespace, and treat these contacts as the same person.  
+5. **Treat `name` fields with different capitalization as the same person.** The current `name` field treats names with different capitalization as separate names, which usually should be referring to the same person. We plan to treat these contacts as the same person.  
+6. **Create unique index identifier for contacts.** The current app uses the `name` field as a unique contact identifier, which prevents multiple contacts of the same name from being added. We plan to add a unique numerical identifier for each contact added, to allow for duplicate names.
+7. **Allow `relate` command to only be performed on people on the current display list.** The current implementation allows the relation of everyone in the app regardless of whether it is currently being filtered and displayed. We plan to only allow for relating contacts on the filtered list to align with other commands like `delete` that can only be performed on the filtered list.
+

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -88,7 +88,7 @@ Command format:
 * `help [COMMAND]`
 
 Notes:
-* The user can type in a command after 'help' to see how to use that command.
+* The user can type in a command after `help` to see how to use that command.
 
 Examples:
 * `help add` will show the user how to use the `add` command.
@@ -141,10 +141,6 @@ Examples:
 * `edit 3 s/` Clears existing subject for the 3rd person.
 * `edit 3 s/Math` Edits the subject of the 3rd person to be `Math`.
 * `edit 4 s/English s/Science` Edits the subjects of the 4th person to be `English` and `Science`.
-
-<box type="tip" seamless>
-
-</box>
 
 ### <span id="relating-persons"></span>Adding or deleting a relation : `relate`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -105,7 +105,11 @@ Command format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [s/SUBJECT]... [t/T
 Notes:
 * A person can have any number of subjects (including 0).
 * A person can have any number of tags (including 0).
-* Person fields are case-sensitive (e.g. `John Doe` and `john doe` are different names, `Math` and `math` are different subjects).
+* Contacts are uniquely identified by name field.
+* All names must be alphanumeric (whitespaces allowed) only and non-empty.
+* Differing whitespace in between words in name field are different contacts (e.g. `John Doe` with one whitespace between `John` and `Doe` is a different contact from `John Doe` with two whitespaces between `John` and `Doe`).
+* Leading or trailing whitespaces in name field are ignored and are the same contact (e.g. ` John` with leading whitespace is the same as `John`).
+* Person fields are case-sensitive (e.g. `John Doe` and `John doe` are different names, `Math` and `math` are different subjects).
 * Phone numbers should contain only digits and be at least 3 digits long, optionally prefixed with a parenthesized country code. Examples: `(+65)12389123`, `12398123`, `(1809)12312093`, `(23-39)1289312`
 
 * Examples:
@@ -263,7 +267,7 @@ Clears all entries from the tutor map. As a safety measure, `clear` returns the 
 
 Command format: `clear confirm`
 
-**Caution**: This action is irreversible! Use `clear confirm` to clear. Any additional whitespace will be ignored.
+**Caution**: This action is irreversible! Use `clear confirm` to clear. Any additional whitespace will be ignored, and the clearing will still proceed.
 
 ### <span id="exiting-program"></span>Exiting the program : `exit`
 
@@ -309,7 +313,7 @@ Action     | Format, Examples
 **Edit**   | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/SUBJECT]... [t/TAG]...`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
 **Find** | `find n/NAME [MORE_NAMES]` e.g., `find n/James Jake` <br> `find r/RELATION` e.g., `find r/mother`, `find r/Alex Yeoh/Bernice Yu` <br> `find a/ADDRESS` e.g., `find a/Blk`, `find a/kent ridge` <br> `find e/EMAIL` e.g., `find e/john@fakemail.com`, `find e/gmail` <br> `find p/PHONE` e.g., `find p/999`, `find p/8` <br> `find s/SUBJECT [MORE_SUBJECTS]` e.g., `find s/math english` <br> `find t/TAG [MORE_TAGS]` e.g., `find t/paid online`
 **List**   | `list`
-**Help**   | `help`
+**Help**   | `help` <br> `help COMMAND` <br> eg. `help add`
 **Relate** | `relate [a\RELATION]... [d\RELATION]...`<br> e.g., `relate a\Bernice Yu/Alex Yeoh/parent/child d\David Li/Charlotte Oliveiro/brother1/brother2`
 **Subject** (rename)|`subject [r\SUBJECT1/SUBJECT2]`<br> e.g., `subject r\Math/Mathematics`
 **Subject** (delete)|`subject [d\SUBJECT1/SUBJECT2/SUBJECT3/...]`<br> e.g., `subject d\Art/History/Mandarin/English`

--- a/src/main/java/seedu/tutor/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/FindCommand.java
@@ -21,7 +21,7 @@ public class FindCommand extends Command {
             + ": Finds all persons whose selected field contains any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Can be used to find people by name, phone number, email, address, subject, relation, or tag. \n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Parameters: [prefix/KEYWORD]...\n"
             + "(Finding by name) Example: " + COMMAND_WORD + " n/alice bob charlie\n"
             + "(Finding by relation) Example: " + COMMAND_WORD + " r/parent\n"
             + "(Finding by subject) Example: " + COMMAND_WORD + " s/math chinese\n"

--- a/src/main/java/seedu/tutor/logic/commands/RelateCommand.java
+++ b/src/main/java/seedu/tutor/logic/commands/RelateCommand.java
@@ -42,12 +42,12 @@ public class RelateCommand extends Command {
             + "[" + PREFIX_RELATE_DELETE + "RELATION]...\n"
 
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_RELATE_ADD + "relate a\\Bernice Yu/Alex Yeoh/parent/child "
-            + "d\\David Li/Charlotte Oliveiro/brother1/brother2\n"
+            + PREFIX_RELATE_ADD + "Bernice Yu/Alex Yeoh/parent/child "
+            + PREFIX_RELATE_DELETE + "David Li/Charlotte Oliveiro/brother1/brother2\n"
 
             + "Notes: \n"
             + "⚠ " + PREFIX_RELATE_ADD + ", " + PREFIX_RELATE_DELETE + " uses backslash (\\), not forward slash (/).\n"
-            + "- RELATION format: [Person1/Person2/Relation-Name1/Relation-Name2]\n"
+            + "- RELATION format: [PERSON1/PERSON2/RELATION_NAME1/RELATION_NAME2]\n"
             + "- " + PREFIX_RELATE_ADD + ", " + PREFIX_RELATE_DELETE
             + "are optional, but at least one must be present.\n"
             + "- " + PREFIX_RELATE_ADD + ", " + PREFIX_RELATE_DELETE + " can be used once or multiple times.";


### PR DESCRIPTION
1. Closes #324 n/ issues:
Closes #297 done already in previous PR
Closes #266 
Closes #294
Closes #241 disallow non-alphanumeric names 

2. Help commands typo:
Closes #296 
Closes #299 

3. Minor bug fixes

4. Add planned enhancements into DG (7 added, we have a max of 10) (these are bug-report prone):
#324 all 4 name limitation issues.
Subject and name fields should allow whitespace and non-alphanumeric.
#245 relate allows for relating on everyone, not only the filtered list. Can limit to only filtered list to match with other commands like delete that only operate on filtered list.

That was more planned enhancements that I expected, lmk if there are any others to be added.

5. Update DG user stories